### PR TITLE
Update tmdb.go

### DIFF
--- a/tmdb/tmdb.go
+++ b/tmdb/tmdb.go
@@ -358,7 +358,7 @@ type APIRequest struct {
 
 const (
 	tmdbEndpoint  = "https://api.themoviedb.org/3"
-	imageEndpoint = "http://image.tmdb.org/t/p/"
+	imageEndpoint = "https://image.tmdb.org/t/p/"
 	burstRate     = 150
 	burstTime     = 10 * time.Second
 	// Currently TMDB is disabled rates limiting


### PR DESCRIPTION
update imageEndpoint url scheme to https due to errors like 
`ERROR: CCurlFile::Stat - Failed: Failure when receiving data from the peer(56) for http://image.tmdb.org/t/p/w500/`