### PR TITLE
Fix burst installation issue

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -896,21 +896,35 @@ func CheckBurst() {
 	// Check for enabled providers and Elementum Burst
 	for _, addon := range xbmc.GetAddons("xbmc.python.script", "executable", "all", []string{"name", "version", "enabled"}).Addons {
 		if strings.HasPrefix(addon.ID, "script.elementum.") {
-			if addon.Enabled == true {
+			if addon.Enabled {
 				return
 			}
 		}
 	}
 
-	time.Sleep(5 * time.Second)
+	for timeout := 0; timeout < 5; timeout++ {
+		if xbmc.IsAddonInstalled("repository.elementum") {
+			break
+		}
+		log.Info("Sleeping 1 second while waiting for Elementum repository add-on to be installed")
+		time.Sleep(1 * time.Second)
+	}
+
 	log.Info("Updating Kodi add-on repositories for Burst...")
 	xbmc.UpdateLocalAddons()
 	xbmc.UpdateAddonRepos()
 
 	if !Get().SkipBurstSearch && xbmc.DialogConfirmFocused("Elementum", "LOCALIZE[30271]") {
 		log.Infof("Triggering Kodi to check for script.elementum.burst plugin")
-		xbmc.PlayURL("plugin://script.elementum.burst/")
-		time.Sleep(15 * time.Second)
+		xbmc.InstallAddon("script.elementum.burst")
+
+		for timeout := 0; timeout < 15; timeout++ {
+			if xbmc.IsAddonInstalled("script.elementum.burst") {
+				break
+			}
+			log.Info("Sleeping 1 second while waiting for script.elementum.burst add-on to be installed")
+			time.Sleep(1 * time.Second)
+		}
 
 		log.Infof("Checking for existence of script.elementum.burst plugin now")
 		if xbmc.IsAddonInstalled("script.elementum.burst") {

--- a/config/config.go
+++ b/config/config.go
@@ -902,7 +902,7 @@ func CheckBurst() {
 		}
 	}
 
-	for timeout := 0; timeout < 5; timeout++ {
+	for timeout := 0; timeout < 10; timeout++ {
 		if xbmc.IsAddonInstalled("repository.elementum") {
 			break
 		}

--- a/migration.go
+++ b/migration.go
@@ -30,7 +30,7 @@ func checkRepository() bool {
 	}
 	log.Info("Elementum repository not installed, installing...")
 	xbmc.InstallAddon("repository.elementum")
-	for timeout := 0; timeout < 3; timeout++ {
+	for timeout := 0; timeout < 10; timeout++ {
 		if xbmc.IsAddonInstalled("repository.elementum") {
 			break
 		}

--- a/migration.go
+++ b/migration.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/elgatito/elementum/repository"
 	"github.com/elgatito/elementum/xbmc"
 )
@@ -28,6 +30,13 @@ func checkRepository() bool {
 	}
 	log.Info("Elementum repository not installed, installing...")
 	xbmc.InstallAddon("repository.elementum")
+	for timeout := 0; timeout < 3; timeout++ {
+		if xbmc.IsAddonInstalled("repository.elementum") {
+			break
+		}
+		log.Info("Sleeping 1 second while waiting for Elementum repository add-on to be installed")
+		time.Sleep(1 * time.Second)
+	}
 	xbmc.SetAddonEnabled("repository.elementum", true)
 	xbmc.UpdateLocalAddons()
 	xbmc.UpdateAddonRepos()


### PR DESCRIPTION
should fix https://github.com/elgatito/plugin.video.elementum/issues/605
2 issues there:
1) code tries to enable repo right after it was installed so in all my tests it will not succeed since installation needs some time
2) invoking `xbmc.PlayURL("plugin://script.elementum.burst/")` hangs kodi by some reason. maybe kodi tries to open burst somehow and hangs. strace did not show reason.

Visually nothing changes - `xbmc.InstallAddon("script.elementum.burst")` still asks user for confirmation.

Tested on kodi 17/18/19.