### PR TITLE
Small fixes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -920,7 +920,7 @@ func CheckBurst() {
 		log.Infof("Triggering Kodi to check for script.elementum.burst plugin")
 		xbmc.InstallAddon("script.elementum.burst")
 
-		for timeout := 0; timeout < 15; timeout++ {
+		for timeout := 0; timeout < 30; timeout++ {
 			if xbmc.IsAddonInstalled("script.elementum.burst") {
 				break
 			}

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -497,7 +497,7 @@ func CollectionShows(isUpdateNeeded bool) (shows []*Shows, err error) {
 		return shows, fmt.Errorf("Bad status getting Trakt collection for shows: %d", resp.Status())
 	}
 
-	var collection []*WatchlistShow
+	var collection []*CollectionShow
 	if err := resp.Unmarshal(&collection); err != nil {
 		log.Warning(err)
 	}


### PR DESCRIPTION
Increase brust installation timeout for slow machines - take some time to install burst dependencies on fresh kodi.

Use proper struck in CollectionShows - functionally changes nothing but removes confusion.