### PR TITLE
Fix deleting files even when "Delete files" is not checked

### DIFF
--- a/api/torrents.go
+++ b/api/torrents.go
@@ -490,7 +490,7 @@ func RemoveTorrent(s *bittorrent.Service) gin.HandlerFunc {
 			return
 		}
 
-		s.RemoveTorrent(torrent, true, deleteFiles != "", false)
+		s.RemoveTorrent(torrent, true, deleteFiles != "" && deleteFiles != "false", false)
 
 		xbmc.Refresh()
 		ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")


### PR DESCRIPTION
There is a problem when you delete a torrent from the web interface. The UI gives you a choice whether you want to delete torrent files or not. 
The problem is that the code deletes the files even though the API is called with `?files=false`:
```
http://<ip>:65220/torrents/delete/<torrent_hash>?files=false
```
This pull request should fix it. I didn't remove the original check for `deleteFiles != ""` as I'm not sure if it's used anywhere, so I think nothing should break.

Please note that _I didn't test it_, but I hope everything is right.