### PR TITLE
fix panics in Torrent.Name() & Torrent.ChooseFile() when magnet is still resolving and you invoke ListTorrents or do shutdown

### DIFF
--- a/bittorrent/torrent.go
+++ b/bittorrent/torrent.go
@@ -1082,7 +1082,7 @@ func (t *Torrent) Name() string {
 		return t.name
 	}
 
-	if t.th == nil {
+	if t.ti.Swigcptr() == 0 {
 		return ""
 	}
 
@@ -1965,6 +1965,10 @@ func (t *Torrent) ChooseFile(btp *Player) (*File, int, error) {
 	if btp == nil {
 		t.DownloadFile(files[biggestFile])
 		t.SaveDBFiles()
+	}
+
+	if len(files) == 0 {
+		return nil, -1, fmt.Errorf("files list is empty")
 	}
 
 	return files[biggestFile], -1, nil


### PR DESCRIPTION
<details><summary>panic when magnet is still resolving and you invoke ListTorrents</summary>

```
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x88 pc=0xfdd5d6]

runtime stack:
runtime.throw(0x16821cd, 0x2a)
	/usr/x86_64-linux-gnu/go/src/runtime/panic.go:1117 +0x72
runtime.sigpanic()
	/usr/x86_64-linux-gnu/go/src/runtime/signal_unix.go:718 +0x2e5

goroutine 1801 [syscall]:
runtime.cgocall(0xfac4b0, 0xc00052f3b8, 0x10)
	/usr/x86_64-linux-gnu/go/src/runtime/cgocall.go:154 +0x5b fp=0xc00052f388 sp=0xc00052f350 pc=0x52bedb
github.com/ElementumOrg/libtorrent-go._Cfunc__wrap_TorrentInfo_Name_libtorrent_59a944e00f7f28f8(0x0, 0x0, 0x0)
	_cgo_gotypes.go:44208 +0x45 fp=0xc00052f3b8 sp=0xc00052f388 pc=0xbd3b85
github.com/ElementumOrg/libtorrent-go.SwigcptrTorrentInfo.Name(0x0, 0x0, 0xc00052f438)
	_libtorrent_swig.go:22978 +0x2b fp=0xc00052f3f8 sp=0xc00052f3b8 pc=0xc08ceb
github.com/ElementumOrg/libtorrent-go.(*SwigcptrTorrentInfo).Name(0x21c0a40, 0xc000728301, 0xc000f1a5d0)
	<autogenerated>:1 +0x3c fp=0xc00052f420 sp=0xc00052f3f8 pc=0xc4aebc
github.com/elgatito/elementum/bittorrent.(*Torrent).Name(0xc000946580, 0x0, 0x2)
	/go/src/github.com/elgatito/elementum/bittorrent/torrent.go:1089 +0x72 fp=0xc00052f448 sp=0xc00052f420 pc=0xeef7f2
github.com/elgatito/elementum/api.ListTorrents.func1(0xc0002de000)
	/go/src/github.com/elgatito/elementum/api/torrents.go:186 +0x146 fp=0xc00052f770 sp=0xc00052f448 pc=0xf73486
github.com/gin-gonic/gin.(*Context).Next(...)
	/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:161
github.com/gin-gonic/gin.LoggerWithConfig.func1(0xc0002de000)
	/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/logger.go:241 +0xf4 fp=0xc00052f910 sp=0xc00052f770 pc=0xb17534
github.com/gin-gonic/gin.(*Context).Next(...)
	/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:161
github.com/gin-gonic/gin.RecoveryWithWriter.func1(0xc0002de000)
	/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/recovery.go:83 +0x71 fp=0xc00052f950 sp=0xc00052f910 pc=0xb184b1
github.com/gin-gonic/gin.(*Context).Next(...)
	/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:161
github.com/gin-gonic/gin.(*Engine).handleHTTPRequest(0xc00016a280, 0xc0002de000)
	/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/gin.go:409 +0x2d0 fp=0xc00052fad8 sp=0xc00052f950 pc=0xb0e670
github.com/gin-gonic/gin.(*Engine).ServeHTTP(0xc00016a280, 0x17b7820, 0xc000662e00, 0xc000fca100)
	/go/pkg/mod/github.com/gin-gonic/gin@v1.6.3/gin.go:367 +0x14d fp=0xc00052fb10 sp=0xc00052fad8 pc=0xb0e10d
net/http.(*ServeMux).ServeHTTP(0x2204dc0, 0x17b7820, 0xc000662e00, 0xc000fca100)
	/usr/x86_64-linux-gnu/go/src/net/http/server.go:2448 +0x1ad fp=0xc00052fb70 sp=0xc00052fb10 pc=0x83bc8d
net/http.serverHandler.ServeHTTP(0xc0004a8000, 0x17b7820, 0xc000662e00, 0xc000fca100)
	/usr/x86_64-linux-gnu/go/src/net/http/server.go:2887 +0xa3 fp=0xc00052fba0 sp=0xc00052fb70 pc=0x83d3c3
net/http.(*conn).serve(0xc00060c000, 0x17baba0, 0xc000728200)
	/usr/x86_64-linux-gnu/go/src/net/http/server.go:1952 +0x8cd fp=0xc00052ffc8 sp=0xc00052fba0 pc=0x8387ed
runtime.goexit()
	/usr/x86_64-linux-gnu/go/src/runtime/asm_amd64.s:1371 +0x1 fp=0xc00052ffd0 sp=0xc00052ffc8 pc=0x59ae01
created by net/http.(*Server).Serve
	/usr/x86_64-linux-gnu/go/src/net/http/server.go:3013 +0x39b

goroutine 1 [IO wait]:
internal/poll.runtime_pollWait(0x7f4bb7738370, 0x72, 0x0)
	/usr/x86_64-linux-gnu/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc000494318, 0x72, 0x0, 0x0, 0x165caa0)
	/usr/x86_64-linux-gnu/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/x86_64-linux-gnu/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Accept(0xc000494300, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/x86_64-linux-gnu/go/src/internal/poll/fd_unix.go:401 +0x212
net.(*netFD).accept(0xc000494300, 0x3d43f1be25be1e20, 0x0, 0x0)
	/usr/x86_64-linux-gnu/go/src/net/fd_unix.go:172 +0x45
net.(*TCPListener).accept(0xc0004c0000, 0x606f8380, 0xc0000d5b68, 0x6046a6)
	/usr/x86_64-linux-gnu/go/src/net/tcpsock_posix.go:139 +0x32
net.(*TCPListener).Accept(0xc0004c0000, 0xc0000d5bb8, 0x18, 0xc000000180, 0x83d8bb)
	/usr/x86_64-linux-gnu/go/src/net/tcpsock.go:261 +0x65
net/http.(*Server).Serve(0xc0004a8000, 0x17b7610, 0xc0004c0000, 0x0, 0x0)
	/usr/x86_64-linux-gnu/go/src/net/http/server.go:2981 +0x285
net/http.(*Server).ListenAndServe(0xc0004a8000, 0xc0004a8000, 0x1)
	/usr/x86_64-linux-gnu/go/src/net/http/server.go:2910 +0xba
net/http.ListenAndServe(...)
	/usr/x86_64-linux-gnu/go/src/net/http/server.go:3164
main.main()
	/go/src/github.com/elgatito/elementum/main.go:236 +0x11d7

goroutine 20 [select]:
github.com/likexian/gokit/xcache/memory.(*Objects).gc(0xc000283c80)
	/go/pkg/mod/github.com/likexian/gokit@v0.24.7/xcache/memory/memory.go:244 +0x29c
created by github.com/likexian/gokit/xcache/memory.New
	/go/pkg/mod/github.com/likexian/gokit@v0.24.7/xcache/memory/memory.go:76 +0xb9

goroutine 21 [select]:
github.com/likexian/doh-go.Use.func1(0xc000145d10)
	/go/pkg/mod/github.com/likexian/doh-go@v0.6.4/doh.go:122 +0x9f
created by github.com/likexian/doh-go.Use
	/go/pkg/mod/github.com/likexian/doh-go@v0.6.4/doh.go:119 +0x277

goroutine 22 [select]:
github.com/likexian/gokit/xcache/memory.(*Objects).gc(0xc000283d80)
	/go/pkg/mod/github.com/likexian/gokit@v0.24.7/xcache/memory/memory.go:244 +0x29c
created by github.com/likexian/gokit/xcache/memory.New
	/go/pkg/mod/github.com/likexian/gokit@v0.24.7/xcache/memory/memory.go:76 +0xb9

goroutine 31 [select, 4 minutes]:
github.com/elgatito/elementum/bittorrent.(*Service).watchConfig.func1(0xc000392300, 0xc000344000)
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:1884 +0x131
created by github.com/elgatito/elementum/bittorrent.(*Service).watchConfig
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:1880 +0x67

goroutine 9 [syscall]:
github.com/ElementumOrg/libtorrent-go._Cfunc__wrap_WrappedSessionHandle_WaitForAlert_libtorrent_59a944e00f7f28f8(0x2ba6b50, 0x2ba7110, 0x0)
	_cgo_gotypes.go:50897 +0x49
github.com/ElementumOrg/libtorrent-go.SwigcptrWrappedSessionHandle.WaitForAlert(0x2ba6b50, 0x17a78e0, 0xc00043e000, 0x17c1488, 0x21c0a40)
	_libtorrent_swig.go:45574 +0x3f
github.com/elgatito/elementum/bittorrent.(*Service).alertsConsumer(0xc000392300)
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:1017 +0x1372
created by github.com/elgatito/elementum/bittorrent.NewService
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:107 +0x2ab

goroutine 10 [chan receive]:
github.com/elgatito/elementum/bittorrent.(*Service).logAlerts(0xc000392300)
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:1115 +0x72
created by github.com/elgatito/elementum/bittorrent.NewService
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:108 +0x2cd

goroutine 12 [sleep]:
time.Sleep(0x1dcd6500)
	/usr/x86_64-linux-gnu/go/src/runtime/time.go:193 +0xd2
github.com/radovskyb/watcher.(*Watcher).Start(0xc000344000, 0x1dcd6500, 0x4e, 0x0)
	/go/pkg/mod/github.com/radovskyb/watcher@v1.0.7/watcher.go:608 +0x2c7
github.com/elgatito/elementum/bittorrent.(*Service).watchConfig(0xc000392300)
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:1905 +0x11d
created by github.com/elgatito/elementum/bittorrent.NewService
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:112 +0x311

goroutine 13 [select]:
github.com/elgatito/elementum/bittorrent.(*Service).saveResumeDataConsumer(0xc000392300)
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:975 +0x125
created by github.com/elgatito/elementum/bittorrent.NewService
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:113 +0x333

goroutine 14 [select]:
github.com/elgatito/elementum/bittorrent.(*Service).saveResumeDataLoop(0xc000392300)
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:949 +0x2f6
created by github.com/elgatito/elementum/bittorrent.NewService
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:114 +0x355

goroutine 49 [select]:
github.com/elgatito/elementum/broadcast.(*Broadcaster).Listen.func1(0xc000384000, 0xc00010e0c0, 0xc00010e120)
	/go/src/github.com/elgatito/elementum/broadcast/broadcast.go:96 +0x145
created by github.com/elgatito/elementum/broadcast.(*Broadcaster).Listen
	/go/src/github.com/elgatito/elementum/broadcast/broadcast.go:90 +0x125

goroutine 82 [chan receive]:
github.com/elgatito/elementum/bittorrent.(*Service).Alerts.func1(0xc00010e0c0, 0xc00010e180)
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:1106 +0x65
created by github.com/elgatito/elementum/bittorrent.(*Service).Alerts
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:1105 +0x96

goroutine 179 [select]:
github.com/elgatito/elementum/library.Init.func2()
	/go/src/github.com/elgatito/elementum/library/library.go:166 +0x185
created by github.com/elgatito/elementum/library.Init
	/go/src/github.com/elgatito/elementum/library/library.go:157 +0x475

goroutine 98 [select]:
github.com/elgatito/elementum/bittorrent.(*Service).downloadProgress(0xc000392300)
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:1233 +0x1525
created by github.com/elgatito/elementum/bittorrent.NewService
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:119 +0x3b1

goroutine 100 [sleep]:
time.Sleep(0x3b9aca00)
	/usr/x86_64-linux-gnu/go/src/runtime/time.go:193 +0xd2
main.main.func2()
	/go/src/github.com/elgatito/elementum/main.go:159 +0x39
created by main.main
	/go/src/github.com/elgatito/elementum/main.go:163 +0x9c9

goroutine 114 [select]:
github.com/elgatito/elementum/broadcast.(*Broadcaster).Listen.func1(0xc00040a130, 0xc00001a000, 0xc00001a060)
	/go/src/github.com/elgatito/elementum/broadcast/broadcast.go:96 +0x145
created by github.com/elgatito/elementum/broadcast.(*Broadcaster).Listen
	/go/src/github.com/elgatito/elementum/broadcast/broadcast.go:90 +0x125

goroutine 115 [chan receive]:
github.com/elgatito/elementum/bittorrent.(*Service).Alerts.func1(0xc00001a000, 0xc00001a0c0)
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:1106 +0x65
created by github.com/elgatito/elementum/bittorrent.(*Service).Alerts
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:1105 +0x96

goroutine 85 [IO wait, 4 minutes]:
internal/poll.runtime_pollWait(0x7f4bb7738458, 0x72, 0xffffffffffffffff)
	/usr/x86_64-linux-gnu/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc0003a0118, 0x72, 0x1200, 0x129a, 0xffffffffffffffff)
	/usr/x86_64-linux-gnu/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/x86_64-linux-gnu/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc0003a0100, 0xc0005f6000, 0x129a, 0x129a, 0x0, 0x0, 0x0)
	/usr/x86_64-linux-gnu/go/src/internal/poll/fd_unix.go:166 +0x1d5
net.(*netFD).Read(0xc0003a0100, 0xc0005f6000, 0x129a, 0x129a, 0x20300000000000, 0x800, 0x800)
	/usr/x86_64-linux-gnu/go/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc000556038, 0xc0005f6000, 0x129a, 0x129a, 0x0, 0x0, 0x0)
	/usr/x86_64-linux-gnu/go/src/net/net.go:183 +0x91
crypto/tls.(*atLeastReader).Read(0xc0005c0768, 0xc0005f6000, 0x129a, 0x129a, 0xc0000189f8, 0xc000540400, 0x0)
	/usr/x86_64-linux-gnu/go/src/crypto/tls/conn.go:776 +0x63
bytes.(*Buffer).ReadFrom(0xc000359078, 0x17a6040, 0xc0005c0768, 0x533f65, 0x155dbe0, 0x161ae00)
	/usr/x86_64-linux-gnu/go/src/bytes/buffer.go:204 +0xbe
crypto/tls.(*Conn).readFromUntil(0xc000358e00, 0x17a6d80, 0xc000556038, 0x5, 0xc000556038, 0x203000)
	/usr/x86_64-linux-gnu/go/src/crypto/tls/conn.go:798 +0xf3
crypto/tls.(*Conn).readRecordOrCCS(0xc000358e00, 0x0, 0x0, 0x56391c)
	/usr/x86_64-linux-gnu/go/src/crypto/tls/conn.go:605 +0x115
crypto/tls.(*Conn).readRecord(...)
	/usr/x86_64-linux-gnu/go/src/crypto/tls/conn.go:573
crypto/tls.(*Conn).Read(0xc000358e00, 0xc0001e5000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/x86_64-linux-gnu/go/src/crypto/tls/conn.go:1276 +0x165
net/http.(*persistConn).Read(0xc000468480, 0xc0001e5000, 0x1000, 0x1000, 0xc000560180, 0xc000018d40, 0x52de15)
	/usr/x86_64-linux-gnu/go/src/net/http/transport.go:1922 +0x77
bufio.(*Reader).fill(0xc000387f20)
	/usr/x86_64-linux-gnu/go/src/bufio/bufio.go:101 +0x108
bufio.(*Reader).Peek(0xc000387f20, 0x1, 0x0, 0x1, 0x4, 0x1, 0x3)
	/usr/x86_64-linux-gnu/go/src/bufio/bufio.go:139 +0x4f
net/http.(*persistConn).readLoop(0xc000468480)
	/usr/x86_64-linux-gnu/go/src/net/http/transport.go:2083 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/x86_64-linux-gnu/go/src/net/http/transport.go:1743 +0xc77

goroutine 154 [select, 4 minutes]:
net/http.(*persistConn).writeLoop(0xc000448360)
	/usr/x86_64-linux-gnu/go/src/net/http/transport.go:2382 +0xf7
created by net/http.(*Transport).dialConn
	/usr/x86_64-linux-gnu/go/src/net/http/transport.go:1744 +0xc9c

goroutine 163 [syscall, 4 minutes]:
os/signal.signal_recv(0x0)
	/usr/x86_64-linux-gnu/go/src/runtime/sigqueue.go:168 +0xa5
os/signal.loop()
	/usr/x86_64-linux-gnu/go/src/os/signal/signal_unix.go:23 +0x25
created by os/signal.Notify.func1.1
	/usr/x86_64-linux-gnu/go/src/os/signal/signal.go:151 +0x45

goroutine 164 [select, 4 minutes]:
main.main.func9(0xc000392300, 0xc000482000, 0xc00007a900)
	/go/src/github.com/elgatito/elementum/main.go:208 +0xa9
created by main.main
	/go/src/github.com/elgatito/elementum/main.go:204 +0xf05

goroutine 166 [select]:
github.com/elgatito/elementum/library.Init()
	/go/src/github.com/elgatito/elementum/library/library.go:304 +0xb18
created by main.main
	/go/src/github.com/elgatito/elementum/main.go:227 +0xf35

goroutine 167 [chan receive, 4 minutes]:
github.com/elgatito/elementum/trakt.TokenRefreshHandler()
	/go/src/github.com/elgatito/elementum/trakt/trakt.go:880 +0xa5
created by main.main
	/go/src/github.com/elgatito/elementum/main.go:228 +0xf4d

goroutine 168 [select, 4 minutes]:
github.com/elgatito/elementum/database.(*StormDatabase).MaintenanceRefreshHandler(0xc00009a570)
	/go/src/github.com/elgatito/elementum/database/storm.go:86 +0x1e9
created by main.main
	/go/src/github.com/elgatito/elementum/main.go:229 +0xf72

goroutine 169 [select, 4 minutes]:
github.com/elgatito/elementum/database.(*BoltDatabase).MaintenanceRefreshHandler(0xc00009a6f0)
	/go/src/github.com/elgatito/elementum/database/bolt.go:139 +0x1fb
created by main.main
	/go/src/github.com/elgatito/elementum/main.go:230 +0xf97

goroutine 153 [IO wait, 4 minutes]:
internal/poll.runtime_pollWait(0x7f4bb77380b8, 0x72, 0xffffffffffffffff)
	/usr/x86_64-linux-gnu/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc000344918, 0x72, 0x1200, 0x129a, 0xffffffffffffffff)
	/usr/x86_64-linux-gnu/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/x86_64-linux-gnu/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc000344900, 0xc00081e000, 0x129a, 0x129a, 0x0, 0x0, 0x0)
	/usr/x86_64-linux-gnu/go/src/internal/poll/fd_unix.go:166 +0x1d5
net.(*netFD).Read(0xc000344900, 0xc00081e000, 0x129a, 0x129a, 0x1295, 0xc00081e000, 0x5)
	/usr/x86_64-linux-gnu/go/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc000556040, 0xc00081e000, 0x129a, 0x129a, 0x0, 0x0, 0x0)
	/usr/x86_64-linux-gnu/go/src/net/net.go:183 +0x91
crypto/tls.(*atLeastReader).Read(0xc000131140, 0xc00081e000, 0x129a, 0x129a, 0xc0000139f8, 0xc0003dc400, 0x0)
	/usr/x86_64-linux-gnu/go/src/crypto/tls/conn.go:776 +0x63
bytes.(*Buffer).ReadFrom(0xc000359af8, 0x17a6040, 0xc000131140, 0x533f65, 0x155dbe0, 0x161ae00)
	/usr/x86_64-linux-gnu/go/src/bytes/buffer.go:204 +0xbe
crypto/tls.(*Conn).readFromUntil(0xc000359880, 0x17a6d80, 0xc000556040, 0x5, 0xc000556040, 0x203000)
	/usr/x86_64-linux-gnu/go/src/crypto/tls/conn.go:798 +0xf3
crypto/tls.(*Conn).readRecordOrCCS(0xc000359880, 0x0, 0x0, 0x56391c)
	/usr/x86_64-linux-gnu/go/src/crypto/tls/conn.go:605 +0x115
crypto/tls.(*Conn).readRecord(...)
	/usr/x86_64-linux-gnu/go/src/crypto/tls/conn.go:573
crypto/tls.(*Conn).Read(0xc000359880, 0xc00082e000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/x86_64-linux-gnu/go/src/crypto/tls/conn.go:1276 +0x165
net/http.(*persistConn).Read(0xc000448360, 0xc00082e000, 0x1000, 0x1000, 0xc00010e360, 0xc000013d40, 0x52de15)
	/usr/x86_64-linux-gnu/go/src/net/http/transport.go:1922 +0x77
bufio.(*Reader).fill(0xc000805740)
	/usr/x86_64-linux-gnu/go/src/bufio/bufio.go:101 +0x108
bufio.(*Reader).Peek(0xc000805740, 0x1, 0x0, 0x1, 0x4, 0x1, 0x3)
	/usr/x86_64-linux-gnu/go/src/bufio/bufio.go:139 +0x4f
net/http.(*persistConn).readLoop(0xc000448360)
	/usr/x86_64-linux-gnu/go/src/net/http/transport.go:2083 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/x86_64-linux-gnu/go/src/net/http/transport.go:1743 +0xc77

goroutine 86 [select, 4 minutes]:
net/http.(*persistConn).writeLoop(0xc000468480)
	/usr/x86_64-linux-gnu/go/src/net/http/transport.go:2382 +0xf7
created by net/http.(*Transport).dialConn
	/usr/x86_64-linux-gnu/go/src/net/http/transport.go:1744 +0xc9c

goroutine 1320 [select]:
github.com/elgatito/elementum/bittorrent.(*Torrent).Watch(0xc000156dc0)
	/go/src/github.com/elgatito/elementum/bittorrent/torrent.go:199 +0x2e5
created by github.com/elgatito/elementum/bittorrent.(*Service).AddTorrent
	/go/src/github.com/elgatito/elementum/bittorrent/service.go:844 +0xc0a

goroutine 1802 [IO wait]:
internal/poll.runtime_pollWait(0x7f4bb7737ee8, 0x72, 0xffffffffffffffff)
	/usr/x86_64-linux-gnu/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc000722598, 0x72, 0x0, 0x1, 0xffffffffffffffff)
	/usr/x86_64-linux-gnu/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/x86_64-linux-gnu/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc000722580, 0xc000c8e8b1, 0x1, 0x1, 0x0, 0x0, 0x0)
	/usr/x86_64-linux-gnu/go/src/internal/poll/fd_unix.go:166 +0x1d5
net.(*netFD).Read(0xc000722580, 0xc000c8e8b1, 0x1, 0x1, 0xc000abb7a0, 0x0, 0xc00004abd8)
	/usr/x86_64-linux-gnu/go/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc000388110, 0xc000c8e8b1, 0x1, 0x1, 0x0, 0x0, 0x0)
	/usr/x86_64-linux-gnu/go/src/net/net.go:183 +0x91
net/http.(*connReader).backgroundRead(0xc000c8e8a0)
	/usr/x86_64-linux-gnu/go/src/net/http/server.go:692 +0x58
created by net/http.(*connReader).startBackgroundRead
	/usr/x86_64-linux-gnu/go/src/net/http/server.go:688 +0xd5
```

</details>


<details><summary>panic when magnet is still resolving and you do shutdown</summary>

```
panic: runtime error: index out of range [0] with length 0

goroutine 762 [running]:
github.com/elgatito/elementum/bittorrent.(*Torrent).ChooseFile(0xc0003aeb00, 0xc000780600, 0x0, 0xc000404ba0, 0x52e301, 0xc0002e56b0)
	/go/src/github.com/elgatito/elementum/bittorrent/torrent.go:1978 +0x13bc
github.com/elgatito/elementum/bittorrent.(*Player).processMetadata(0xc000780600)
	/go/src/github.com/elgatito/elementum/bittorrent/player.go:318 +0x94
created by github.com/elgatito/elementum/bittorrent.(*Player).Buffer
	/go/src/github.com/elgatito/elementum/bittorrent/player.go:255 +0xe5
```

</details>