### PR TITLE
Add assign torrent functionality

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -65,8 +65,6 @@ func ContextPlaySelector(s *bittorrent.Service) gin.HandlerFunc {
 		log.Error(err.Error())
 		xbmc.Notify("Elementum", err.Error(), config.AddonIcon())
 		ctx.Error(errors.New("Cannot find TMDB for selected Kodi item"))
-		// this will try several times, i guess we don't need this behaviour here
-		//ctx.String(404, "Cannot find TMDB for selected Kodi item")
 		return
 	}
 }

--- a/api/context.go
+++ b/api/context.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -10,9 +11,11 @@ import (
 	"github.com/elgatito/elementum/bittorrent"
 	"github.com/elgatito/elementum/config"
 	"github.com/elgatito/elementum/library"
+	"github.com/elgatito/elementum/tmdb"
+	"github.com/elgatito/elementum/xbmc"
 )
 
-// ContextPlaySelector ...
+// ContextPlaySelector plays/downloads media from Kodi in elementum
 func ContextPlaySelector(s *bittorrent.Service) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
@@ -58,8 +61,147 @@ func ContextPlaySelector(s *bittorrent.Service) gin.HandlerFunc {
 			}
 		}
 
-		log.Debugf("Cound not find TMDB entry for requested Kodi item %d of type %s", kodiID, media)
-		ctx.String(404, "Cannot find TMDB for selected Kodi item")
+		err := fmt.Errorf("Cound not find TMDB entry for requested Kodi item %d of type %s", kodiID, media)
+		log.Error(err.Error())
+		xbmc.Notify("Elementum", err.Error(), config.AddonIcon())
+		ctx.Error(errors.New("Cannot find TMDB for selected Kodi item"))
+		// this will try several times, i guess we don't need this behaviour here
+		//ctx.String(404, "Cannot find TMDB for selected Kodi item")
+		return
+	}
+}
+
+// ContextAssignKodiSelector assigns torrent to movie/episode by Kodi library ID
+func ContextAssignKodiSelector(s *bittorrent.Service) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+
+		torrentID := ctx.Params.ByName("torrentId")
+		id := ctx.Params.ByName("kodiID")
+		kodiID, _ := strconv.Atoi(id)
+		media := ctx.Params.ByName("media")
+
+		var tmdbID int
+
+		if kodiID != 0 {
+			if media == "movie" {
+				if m := library.GetLibraryMovie(kodiID); m != nil && m.UIDs.TMDB != 0 {
+					tmdbID = m.UIDs.TMDB
+					ctx.Redirect(302, URLQuery(URLForXBMC("/context/torrents/assign/%s/tmdb/%s/%d", torrentID, media, tmdbID)))
+					return
+				}
+			} else if media == "episode" {
+				if s, e := library.GetLibraryEpisode(kodiID); s != nil && e != nil && s.UIDs.TMDB != 0 {
+					tmdbID = s.UIDs.TMDB
+					ctx.Redirect(302, URLQuery(URLForXBMC("/context/torrents/assign/%s/tmdb/show/%d/season/%d/%s/%d", torrentID, tmdbID, e.Season, media, e.Episode)))
+					return
+				}
+			} else if media == "season" {
+				if s, se := library.GetLibrarySeason(kodiID); s != nil && se != nil && s.UIDs.TMDB != 0 {
+					tmdbID = s.UIDs.TMDB
+					ctx.Redirect(302, URLQuery(URLForXBMC("/context/torrents/assign/%s/tmdb/show/%d/%s/%d", torrentID, tmdbID, media, se.Season)))
+					return
+				}
+			}
+		}
+
+		err := fmt.Errorf("Cound not find TMDB entry for requested Kodi item %d of type %s", kodiID, media)
+		log.Error(err.Error())
+		xbmc.Notify("Elementum", err.Error(), config.AddonIcon())
+		ctx.Error(errors.New("Cannot find TMDB for selected Kodi item"))
+		return
+	}
+}
+
+// ContextAssignTMDBMovieSelector assigns torrent to movie by TMDB ID
+func ContextAssignTMDBMovieSelector(s *bittorrent.Service) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+
+		torrentID := ctx.Params.ByName("torrentId")
+		id := ctx.Params.ByName("tmdbId")
+		tmdbID, _ := strconv.Atoi(id)
+		media := ctx.Params.ByName("media")
+
+		if tmdbID != 0 {
+			ctx.Redirect(302, URLQuery(URLForXBMC("/torrents/assign/%s/%d", torrentID, tmdbID)))
+			return
+		}
+
+		err := fmt.Errorf("Cound not find TMDB entry for requested Kodi item %d of type %s", tmdbID, media)
+		log.Error(err.Error())
+		xbmc.Notify("Elementum", err.Error(), config.AddonIcon())
+		ctx.Error(errors.New("Cannot find TMDB for selected Kodi item"))
+		return
+	}
+}
+
+// ContextAssignTMDBSeasonSelector assigns torrent to season by show TMDB ID and season number
+func ContextAssignTMDBSeasonSelector(s *bittorrent.Service) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+
+		torrentID := ctx.Params.ByName("torrentId")
+		id := ctx.Params.ByName("tmdbId")
+		showID, _ := strconv.Atoi(id)
+		media := ctx.Params.ByName("media")
+		seasonN := ctx.Params.ByName("season")
+		seasonNumber, _ := strconv.Atoi(seasonN)
+
+		if showID != 0 && seasonNumber != 0 {
+			season := tmdb.GetSeason(showID, seasonNumber, config.Get().Language, 0)
+			if season == nil {
+				err := errors.New("Unable to find season")
+				log.Error(err.Error())
+				xbmc.Notify("Elementum", err.Error(), config.AddonIcon())
+				ctx.Error(err)
+				return
+			}
+
+			ctx.Redirect(302, URLQuery(URLForXBMC("/torrents/assign/%s/%d", torrentID, season.ID)))
+			return
+		}
+
+		err := fmt.Errorf("Cound not find TMDB entry for requested Kodi item %d of type %s #%d", showID, media, seasonNumber)
+		log.Error(err.Error())
+		xbmc.Notify("Elementum", err.Error(), config.AddonIcon())
+		ctx.Error(errors.New("Cannot find TMDB for selected Kodi item"))
+		return
+	}
+}
+
+// ContextAssignTMDBEpisodeSelector assigns torrent to episode by show TMDB ID and season/episode numbers
+func ContextAssignTMDBEpisodeSelector(s *bittorrent.Service) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+
+		torrentID := ctx.Params.ByName("torrentId")
+		id := ctx.Params.ByName("tmdbId")
+		showID, _ := strconv.Atoi(id)
+		media := ctx.Params.ByName("media")
+		seasonN := ctx.Params.ByName("season")
+		seasonNumber, _ := strconv.Atoi(seasonN)
+		episodeN := ctx.Params.ByName("episode")
+		episodeNumber, _ := strconv.Atoi(episodeN)
+
+		if showID != 0 && seasonNumber != 0 {
+			episode := tmdb.GetEpisode(showID, seasonNumber, episodeNumber, config.Get().Language)
+			if episode == nil {
+				err := errors.New("Unable to find episode")
+				log.Error(err.Error())
+				xbmc.Notify("Elementum", err.Error(), config.AddonIcon())
+				ctx.Error(err)
+				return
+			}
+
+			ctx.Redirect(302, URLQuery(URLForXBMC("/torrents/assign/%s/%d", torrentID, episode.ID)))
+			return
+		}
+
+		err := fmt.Errorf("Cound not find TMDB entry for requested Kodi item %d of type %s S%dE%d", showID, media, seasonNumber, episodeNumber)
+		log.Error(err.Error())
+		xbmc.Notify("Elementum", err.Error(), config.AddonIcon())
+		ctx.Error(errors.New("Cannot find TMDB for selected Kodi item"))
 		return
 	}
 }

--- a/api/index.go
+++ b/api/index.go
@@ -32,7 +32,7 @@ func Index(s *bittorrent.Service) gin.HandlerFunc {
 			{Label: "LOCALIZE[30209]", Path: URLForXBMC("/search"), Thumbnail: config.AddonResource("img", "search.png")},
 			{Label: "LOCALIZE[30229]", Path: URLForXBMC("/torrents/"), Thumbnail: config.AddonResource("img", "cloud.png")},
 			{Label: "LOCALIZE[30216]", Path: URLForXBMC("/playtorrent"), Thumbnail: config.AddonResource("img", "magnet.png")},
-			{Label: "LOCALIZE[30537]", Path: URLForXBMC("/history"), Thumbnail: config.AddonResource("img", "clock.png")},
+			{Label: "LOCALIZE[30537]", Path: URLForXBMC("/history/"), Thumbnail: config.AddonResource("img", "clock.png")},
 			{Label: "LOCALIZE[30239]", Path: URLForXBMC("/provider/"), Thumbnail: config.AddonResource("img", "shield.png")},
 			{Label: "LOCALIZE[30355]", Path: URLForXBMC("/changelog"), Thumbnail: config.AddonResource("img", "faq8.png")},
 			{Label: "LOCALIZE[30393]", Path: URLForXBMC("/status"), Thumbnail: config.AddonResource("img", "clock.png")},

--- a/api/routes.go
+++ b/api/routes.go
@@ -83,6 +83,7 @@ func Routes(s *bittorrent.Service) *gin.Engine {
 		torrents.GET("/undownloadall/:torrentId", UnDownloadAllTorrent(s))
 		torrents.GET("/selectfile/:torrentId", SelectFileTorrent(s, true))
 		torrents.GET("/downloadfile/:torrentId", SelectFileTorrent(s, false))
+		torrents.GET("/assign/:torrentId/:tmdbId", AssignTorrent(s))
 
 		// Web UI json
 		torrents.GET("/list", ListTorrentsWeb(s))
@@ -270,7 +271,14 @@ func Routes(s *bittorrent.Service) *gin.Engine {
 
 	context := r.Group("/context")
 	{
-		context.GET("/:media/:kodiID/:action", ContextPlaySelector(s))
+		context.GET("/media/:media/:kodiID/:action", ContextPlaySelector(s))
+		torrents := context.Group("/torrents")
+		{
+			torrents.GET("/assign/:torrentId/kodi/:media/:kodiID", ContextAssignKodiSelector(s))
+			torrents.GET("/assign/:torrentId/tmdb/movie/:tmdbId", ContextAssignTMDBMovieSelector(s))
+			torrents.GET("/assign/:torrentId/tmdb/show/:tmdbId/season/:season", ContextAssignTMDBSeasonSelector(s))
+			torrents.GET("/assign/:torrentId/tmdb/show/:tmdbId/season/:season/episode/:episode", ContextAssignTMDBEpisodeSelector(s))
+		}
 	}
 
 	provider := r.Group("/provider")

--- a/api/routes.go
+++ b/api/routes.go
@@ -46,6 +46,7 @@ func Routes(s *bittorrent.Service) *gin.Engine {
 	history := r.Group("/history")
 	{
 		history.GET("", History)
+		history.GET("/", History)
 		history.GET("/remove", HistoryRemove)
 		history.GET("/clear", HistoryClear)
 	}

--- a/api/torrents.go
+++ b/api/torrents.go
@@ -89,11 +89,11 @@ func AssignTorrent(s *bittorrent.Service) gin.HandlerFunc {
 
 		log.Infof("AssignTorrent %s to tmdbID %s", torrentID, tmdbID)
 
-		//make old torrent disappear from "found in active torrents" dialog in runtime
+		// make old torrent disappear from "found in active torrents" dialog in runtime
 		tmdbInt, _ := strconv.Atoi(tmdbID)
 		var ti database.TorrentAssignItem
 		if err := database.GetStormDB().One("TmdbID", tmdbInt, &ti); err == nil {
-			//check that old torrent is not equal to chosen torrent
+			// check that old torrent is not equal to chosen torrent
 			oldInfoHash := ti.InfoHash
 			if oldInfoHash != torrent.InfoHash() {
 				oldTorrent := s.GetTorrentByHash(oldInfoHash)
@@ -106,10 +106,10 @@ func AssignTorrent(s *bittorrent.Service) gin.HandlerFunc {
 
 		database.GetStorm().AddTorrentLink(tmdbID, torrent.InfoHash(), torrent.GetMetadata(), false)
 
-		//TODO: if we will pass media type and season/episode number to this func, then we also can
-		//update torrent's DBItem in queue so it will be used in "found in active torrents" dialog in runtime
-		//torrent.DBItem.ID/ShowID/Season/Episode = tmdbInt/...
-		//but this will make things uglier and it does not give much value
+		// TODO: if we will pass media type and season/episode number to this func, then we also can
+		// update torrent's DBItem in queue so it will be used in "found in active torrents" dialog in runtime
+		// torrent.DBItem.ID/ShowID/Season/Episode = tmdbInt/...
+		// but this will make things uglier and it does not give much value
 
 		ctx.JSON(200, nil)
 	}

--- a/api/torrents.go
+++ b/api/torrents.go
@@ -71,6 +71,50 @@ func AddToTorrentsMap(tmdbID string, torrent *bittorrent.TorrentFile) {
 	database.GetStorm().AddTorrentLink(tmdbID, torrent.InfoHash, b, false)
 }
 
+// AssignTorrent assigns torrent by its id to elementum's item by its TMDB id
+func AssignTorrent(s *bittorrent.Service) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+
+		torrentID := ctx.Params.ByName("torrentId")
+		torrent, err := GetTorrentFromParam(s, torrentID)
+		if err != nil {
+			log.Error(err.Error())
+			xbmc.Notify("Elementum", err.Error(), config.AddonIcon())
+			ctx.Error(err)
+			return
+		}
+
+		tmdbID := ctx.Params.ByName("tmdbId")
+
+		log.Infof("AssignTorrent %s to tmdbID %s", torrentID, tmdbID)
+
+		//make old torrent disappear from "found in active torrents" dialog in runtime
+		tmdbInt, _ := strconv.Atoi(tmdbID)
+		var ti database.TorrentAssignItem
+		if err := database.GetStormDB().One("TmdbID", tmdbInt, &ti); err == nil {
+			//check that old torrent is not equal to chosen torrent
+			oldInfoHash := ti.InfoHash
+			if oldInfoHash != torrent.InfoHash() {
+				oldTorrent := s.GetTorrentByHash(oldInfoHash)
+				if oldTorrent != nil {
+					oldTorrent.DBItem.ID = 0
+					oldTorrent.DBItem.ShowID = 0
+				}
+			}
+		}
+
+		database.GetStorm().AddTorrentLink(tmdbID, torrent.InfoHash(), torrent.GetMetadata(), false)
+
+		//TODO: if we will pass media type and season/episode number to this func, then we also can
+		//update torrent's DBItem in queue so it will be used in "found in active torrents" dialog in runtime
+		//torrent.DBItem.ID/ShowID/Season/Episode = tmdbInt/...
+		//but this will make things uglier and it does not give much value
+
+		ctx.JSON(200, nil)
+	}
+}
+
 // InTorrentsMap ...
 func InTorrentsMap(tmdbID string) *bittorrent.TorrentFile {
 	if !config.Get().UseCacheSelection || tmdbID == "" {

--- a/database/storm.go
+++ b/database/storm.go
@@ -184,7 +184,7 @@ func (d *StormDatabase) CleanupTorrentLink(infoHash string) {
 	defer perf.ScopeTimer()()
 
 	var oldTi TorrentAssignItem
-	//check that there is no TorrentAssignItem left and only then delete TorrentAssignMetadata
+	// check that there is no TorrentAssignItem left and only then delete TorrentAssignMetadata
 	if err := d.db.Select(q.Eq("InfoHash", infoHash)).First(&oldTi); err != nil {
 		if err := d.db.Delete(TorrentAssignMetadataBucket, infoHash); err != nil {
 			log.Errorf("Could not delete old torrent metadata: %s", err)
@@ -209,7 +209,7 @@ func (d *StormDatabase) AddTorrentLink(tmdbID, infoHash string, b []byte, force 
 			InfoHash: infoHash,
 			Metadata: b,
 		}
-		//we could use just Save() since TorrentAssignMetadata does not have unique field, but bettert to be explicit
+		// we could use just Save() since TorrentAssignMetadata does not have unique field, but bettert to be explicit
 		if err == nil {
 			d.db.Update(&tm)
 		} else {
@@ -222,7 +222,7 @@ func (d *StormDatabase) AddTorrentLink(tmdbID, infoHash string, b []byte, force 
 	var ti TorrentAssignItem
 	if err := d.db.One("TmdbID", tmdbInt, &ti); err == nil {
 		oldInfoHash := ti.InfoHash
-		//check that old torrent is not equal to new torrent
+		// check that old torrent is not equal to new torrent
 		if oldInfoHash != infoHash {
 			ti.InfoHash = infoHash
 			log.Infof("Update torrent info, old %s, new %s", oldInfoHash, infoHash)
@@ -232,7 +232,7 @@ func (d *StormDatabase) AddTorrentLink(tmdbID, infoHash string, b []byte, force 
 
 			d.CleanupTorrentLink(oldInfoHash)
 
-			//make old torrent disappear from "found in active torrents" dialog after restart
+			// make old torrent disappear from "found in active torrents" dialog after restart
 			oldBTItem := d.GetBTItem(oldInfoHash)
 			if oldBTItem != nil {
 				if err := d.db.UpdateField(oldBTItem, "ID", 0); err != nil {

--- a/database/storm.go
+++ b/database/storm.go
@@ -183,10 +183,11 @@ func (d *StormDatabase) RemoveSearchHistory(historyType, query string) {
 func (d *StormDatabase) CleanupTorrentLink(infoHash string) {
 	defer perf.ScopeTimer()()
 
-	var tiOld TorrentAssignItem
-	if err := d.db.Select(q.Eq("InfoHash", infoHash)).First(&tiOld); err != nil {
+	var oldTi TorrentAssignItem
+	//check that there is no TorrentAssignItem left and only then delete TorrentAssignMetadata
+	if err := d.db.Select(q.Eq("InfoHash", infoHash)).First(&oldTi); err != nil {
 		if err := d.db.Delete(TorrentAssignMetadataBucket, infoHash); err != nil {
-			log.Debugf("Could not delete old torrent metadata: %s", err)
+			log.Errorf("Could not delete old torrent metadata: %s", err)
 		}
 	}
 }
@@ -208,19 +209,40 @@ func (d *StormDatabase) AddTorrentLink(tmdbID, infoHash string, b []byte, force 
 			InfoHash: infoHash,
 			Metadata: b,
 		}
-		d.db.Save(&tm)
+		//we could use just Save() since TorrentAssignMetadata does not have unique field, but bettert to be explicit
+		if err == nil {
+			d.db.Update(&tm)
+		} else {
+			d.db.Save(&tm)
+		}
 	}
 
 	tmdbInt, _ := strconv.Atoi(tmdbID)
+
 	var ti TorrentAssignItem
 	if err := d.db.One("TmdbID", tmdbInt, &ti); err == nil {
 		oldInfoHash := ti.InfoHash
-		ti.InfoHash = infoHash
-		if err := d.db.Update(&ti); err != nil {
-			log.Debugf("Could not update torrent info: %s", err)
-		}
+		//check that old torrent is not equal to new torrent
+		if oldInfoHash != infoHash {
+			ti.InfoHash = infoHash
+			log.Infof("Update torrent info, old %s, new %s", oldInfoHash, infoHash)
+			if err := d.db.Update(&ti); err != nil {
+				log.Errorf("Could not update torrent info: %s", err)
+			}
 
-		d.CleanupTorrentLink(oldInfoHash)
+			d.CleanupTorrentLink(oldInfoHash)
+
+			//make old torrent disappear from "found in active torrents" dialog after restart
+			oldBTItem := d.GetBTItem(oldInfoHash)
+			if oldBTItem != nil {
+				if err := d.db.UpdateField(oldBTItem, "ID", 0); err != nil {
+					log.Errorf("Could not update old BTItem's ID: %s", err)
+				}
+				if err := d.db.UpdateField(oldBTItem, "ShowID", 0); err != nil {
+					log.Errorf("Could not update old BTItem's ShowID: %s", err)
+				}
+			}
+		}
 		return
 	}
 
@@ -229,7 +251,7 @@ func (d *StormDatabase) AddTorrentLink(tmdbID, infoHash string, b []byte, force 
 		TmdbID:   tmdbInt,
 	}
 	if err := d.db.Save(&ti); err != nil {
-		log.Debugf("Could not insert torrent info: %s", err)
+		log.Errorf("Could not insert torrent info: %s", err)
 	}
 }
 

--- a/xbmc/xbmcgui.go
+++ b/xbmc/xbmcgui.go
@@ -192,6 +192,13 @@ func Dialog(title string, message string) bool {
 	return retVal != 0
 }
 
+// DialogBrowseSingle ...
+func DialogBrowseSingle(browseType int, title string, shares string, mask string, useThumbs bool, treatAsFolder bool, defaultt string) string {
+	retVal := ""
+	executeJSONRPCEx("Dialog_Browse_Single", &retVal, Args{browseType, title, shares, mask, useThumbs, treatAsFolder, defaultt})
+	return retVal
+}
+
 // DialogConfirm ...
 func DialogConfirm(title string, message string) bool {
 	return dialogConfirmRunner(title, message, false)


### PR DESCRIPTION
Adds the possibility to assign "known torrent" (by hash) either by kodi library id or by tmdb id.

More details https://github.com/elgatito/context.elementum/pull/13