### PR TITLE
Fix internal subtitles provider

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -62,6 +62,7 @@ func Routes(s *bittorrent.Service) *gin.Engine {
 	r.GET("/status", Status)
 
 	r.Any("/info", s.ClientInfo)
+	r.Any("/info/*ident", s.ClientInfo)
 
 	history := r.Group("/history")
 	{

--- a/api/routes.go
+++ b/api/routes.go
@@ -62,7 +62,6 @@ func Routes(s *bittorrent.Service) *gin.Engine {
 	r.GET("/status", Status)
 
 	r.Any("/info", s.ClientInfo)
-	r.Any("/info/*ident", s.ClientInfo)
 
 	history := r.Group("/history")
 	{

--- a/api/subtitles.go
+++ b/api/subtitles.go
@@ -30,7 +30,11 @@ func SubtitlesIndex(s *bittorrent.Service) gin.HandlerFunc {
 			playingFile, _ = url.QueryUnescape(playingFile)
 		}
 
-		payloads, preferredLanguage := osdb.GetPayloads(q.Get("searchstring"), strings.Split(q.Get("languages"), ","), q.Get("preferredlanguage"), s.GetActivePlayer().Params().ShowID, playingFile)
+		showID := 0
+		if s.GetActivePlayer() != nil {
+			showID = s.GetActivePlayer().Params().ShowID
+		}
+		payloads, preferredLanguage := osdb.GetPayloads(q.Get("searchstring"), strings.Split(q.Get("languages"), ","), q.Get("preferredlanguage"), showID, playingFile)
 		subLog.Infof("Subtitles payload: %#v", payloads)
 
 		results, err := osdb.DoSearch(payloads, preferredLanguage)

--- a/api/subtitles.go
+++ b/api/subtitles.go
@@ -27,7 +27,8 @@ func SubtitlesIndex(s *bittorrent.Service) gin.HandlerFunc {
 		// Check if we are reading a file from Elementum
 		if strings.HasPrefix(playingFile, util.GetContextHTTPHost(ctx)) {
 			playingFile = strings.Replace(playingFile, util.GetContextHTTPHost(ctx)+"/files", config.Get().DownloadPath, 1)
-			playingFile, _ = url.QueryUnescape(playingFile)
+			// not QueryUnescape in order to treat "+" as "+" in file name on FS
+			playingFile, _ = url.PathUnescape(playingFile)
 		}
 
 		showID := 0

--- a/osdb/util.go
+++ b/osdb/util.go
@@ -170,6 +170,7 @@ func GetPayloads(searchString string, languages []string, preferredLanguage stri
 func appendLocalFilePayloads(playingFile string, payloads *[]SearchPayload) error {
 	file, err := os.Open(playingFile)
 	if err != nil {
+		log.Debug(err)
 		return err
 	}
 	defer file.Close()

--- a/osdb/util.go
+++ b/osdb/util.go
@@ -101,7 +101,7 @@ func GetPayloads(searchString string, languages []string, preferredLanguage stri
 		"VideoPlayer.Title",
 		"VideoPlayer.OriginalTitle",
 		"VideoPlayer.Year",
-		"VideoPlayer.TVshowtitle",
+		"VideoPlayer.TVShowTitle",
 		"VideoPlayer.Season",
 		"VideoPlayer.Episode",
 		"VideoPlayer.IMDBNumber",
@@ -130,10 +130,10 @@ func GetPayloads(searchString string, languages []string, preferredLanguage stri
 		// If player ListItem has IMDBNumber specified - we try to get TMDB item from it.
 		// If not - we can use localized show/movie name - which is not always found on OSDB.
 		if strings.HasPrefix(labels["VideoPlayer.IMDBNumber"], "tt") {
-			if labels["VideoPlayer.TVshowtitle"] != "" {
+			if labels["VideoPlayer.TVShowTitle"] != "" {
 				r := tmdb.Find(labels["VideoPlayer.IMDBNumber"], "imdb_id")
 				if r != nil && len(r.TVResults) > 0 {
-					labels["VideoPlayer.TVshowtitle"] = r.TVResults[0].OriginalName
+					labels["VideoPlayer.TVShowTitle"] = r.TVResults[0].OriginalName
 				}
 			} else {
 				r := tmdb.Find(labels["VideoPlayer.IMDBNumber"], "imdb_id")
@@ -146,7 +146,7 @@ func GetPayloads(searchString string, languages []string, preferredLanguage stri
 		var err error
 		if showID != 0 {
 			err = appendEpisodePayloads(showID, labels, &payloads)
-		} else if err == nil {
+		} else {
 			err = appendMoviePayloads(labels, &payloads)
 		}
 
@@ -234,7 +234,7 @@ func appendEpisodePayloads(showID int, labels map[string]string, payloads *[]Sea
 	}
 
 	if season >= 0 && episode > 0 {
-		title := labels["VideoPlayer.TVshowtitle"]
+		title := labels["VideoPlayer.TVShowTitle"]
 		if showID != 0 {
 			// Trying to get Original name of the show, otherwise we will likely fail to find anything.
 			show := tmdb.GetShow(showID, config.Get().Language)

--- a/xbmc/xbmcgui.go
+++ b/xbmc/xbmcgui.go
@@ -155,7 +155,7 @@ func Notify(header string, message string, image string) {
 // InfoLabels ...
 func InfoLabels(labels ...string) map[string]string {
 	var retVal map[string]string
-	executeJSONRPC("GetInfoLabels", &retVal, Args{labels})
+	executeJSONRPC("XBMC.GetInfoLabels", &retVal, Args{labels})
 	return retVal
 }
 


### PR DESCRIPTION
should be `XBMC.GetInfoLabels` - https://kodi.wiki/view/JSON-RPC_API/v12#XBMC.GetInfoLabels (bad rename in https://github.com/elgatito/elementum/commit/6ecaacaf7a98e164044eccc9c76504906acca4d0 i guess)

also fixes panic in elementum's subtitles provider when open video directly in Kodi (not from library).

plus tiny refactoring.