### PR TITLE
add status_code to /torrents/list

### DIFF
--- a/api/torrents.go
+++ b/api/torrents.go
@@ -35,6 +35,7 @@ type TorrentsWeb struct {
 	Name          string  `json:"name"`
 	Size          string  `json:"size"`
 	Status        string  `json:"status"`
+	StatusEnum    int     `json:"status_enum"`
 	Progress      float64 `json:"progress"`
 	Ratio         float64 `json:"ratio"`
 	TimeRatio     float64 `json:"time_ratio"`
@@ -229,7 +230,8 @@ func ListTorrents(s *bittorrent.Service) gin.HandlerFunc {
 
 			torrentName := t.Name()
 			progress := t.GetProgress()
-			status := xbmc.Translate(t.GetStateString())
+			status, _ := t.GetStateString()
+			status = xbmc.Translate(status)
 
 			torrentAction := []string{"LOCALIZE[30231]", fmt.Sprintf("RunPlugin(%s)", URLForXBMC("/torrents/pause/%s", t.InfoHash()))}
 			sessionAction := []string{"LOCALIZE[30233]", fmt.Sprintf("RunPlugin(%s)", URLForXBMC("/torrents/pause"))}
@@ -329,7 +331,9 @@ func ListTorrentsWeb(s *bittorrent.Service) gin.HandlerFunc {
 			progress := float64(torrentStatus.GetProgress()) * 100
 
 			infoHash := t.InfoHash()
-			status := xbmc.Translate(t.GetStateString())
+
+			status, statusEnum := t.GetStateString()
+			status = xbmc.Translate(status)
 
 			ratio := float64(0)
 			allTimeDownload := float64(torrentStatus.GetAllTimeDownload())
@@ -361,6 +365,7 @@ func ListTorrentsWeb(s *bittorrent.Service) gin.HandlerFunc {
 				Name:          torrentName,
 				Size:          size,
 				Status:        status,
+				StatusEnum:    statusEnum,
 				Progress:      progress,
 				Ratio:         ratio,
 				TimeRatio:     timeRatio,

--- a/api/torrents.go
+++ b/api/torrents.go
@@ -35,7 +35,7 @@ type TorrentsWeb struct {
 	Name          string  `json:"name"`
 	Size          string  `json:"size"`
 	Status        string  `json:"status"`
-	StatusEnum    int     `json:"status_enum"`
+	StatusCode    int     `json:"status_code"`
 	Progress      float64 `json:"progress"`
 	Ratio         float64 `json:"ratio"`
 	TimeRatio     float64 `json:"time_ratio"`
@@ -230,8 +230,8 @@ func ListTorrents(s *bittorrent.Service) gin.HandlerFunc {
 
 			torrentName := t.Name()
 			progress := t.GetProgress()
-			status, _ := t.GetStateString()
-			status = xbmc.Translate(status)
+			statusCode := t.GetSmartState()
+			status := xbmc.Translate(bittorrent.StatusStrings[statusCode])
 
 			torrentAction := []string{"LOCALIZE[30231]", fmt.Sprintf("RunPlugin(%s)", URLForXBMC("/torrents/pause/%s", t.InfoHash()))}
 			sessionAction := []string{"LOCALIZE[30233]", fmt.Sprintf("RunPlugin(%s)", URLForXBMC("/torrents/pause"))}
@@ -332,8 +332,8 @@ func ListTorrentsWeb(s *bittorrent.Service) gin.HandlerFunc {
 
 			infoHash := t.InfoHash()
 
-			status, statusEnum := t.GetStateString()
-			status = xbmc.Translate(status)
+			statusCode := t.GetSmartState()
+			status := xbmc.Translate(bittorrent.StatusStrings[statusCode])
 
 			ratio := float64(0)
 			allTimeDownload := float64(torrentStatus.GetAllTimeDownload())
@@ -365,7 +365,7 @@ func ListTorrentsWeb(s *bittorrent.Service) gin.HandlerFunc {
 				Name:          torrentName,
 				Size:          size,
 				Status:        status,
-				StatusEnum:    statusEnum,
+				StatusCode:    statusCode,
 				Progress:      progress,
 				Ratio:         ratio,
 				TimeRatio:     timeRatio,

--- a/bittorrent/player.go
+++ b/bittorrent/player.go
@@ -413,7 +413,7 @@ func (btp *Player) statusStrings(progress float64, status lt.TorrentStatus) (str
 		progress = 0
 	}
 
-	statusName := btp.t.GetStateString()
+	statusName, _ := btp.t.GetStateString()
 	line1 := fmt.Sprintf("%s (%.2f%%)", statusName, progress)
 
 	// Adding buffer size to progress window

--- a/bittorrent/player.go
+++ b/bittorrent/player.go
@@ -413,7 +413,8 @@ func (btp *Player) statusStrings(progress float64, status lt.TorrentStatus) (str
 		progress = 0
 	}
 
-	statusName, _ := btp.t.GetStateString()
+	statusCode := btp.t.GetSmartState()
+	statusName := StatusStrings[statusCode]
 	line1 := fmt.Sprintf("%s (%.2f%%)", statusName, progress)
 
 	// Adding buffer size to progress window

--- a/bittorrent/service.go
+++ b/bittorrent/service.go
@@ -1247,7 +1247,7 @@ func (s *Service) downloadProgress() {
 
 				t := s.GetTorrentByHash(infoHash)
 				if t != nil {
-					status = t.GetStateString()
+					status, _ = t.GetStateString()
 				} else {
 					continue
 				}

--- a/bittorrent/service.go
+++ b/bittorrent/service.go
@@ -1247,7 +1247,8 @@ func (s *Service) downloadProgress() {
 
 				t := s.GetTorrentByHash(infoHash)
 				if t != nil {
-					status, _ = t.GetStateString()
+					statusCode := t.GetSmartState()
+					status = StatusStrings[statusCode]
 				} else {
 					continue
 				}

--- a/bittorrent/torrent.go
+++ b/bittorrent/torrent.go
@@ -798,12 +798,12 @@ func (t *Torrent) GetState() int {
 	return int(st.GetState())
 }
 
-// GetStateString ...
-func (t *Torrent) GetStateString() (string, int) {
+// GetSmartState ...
+func (t *Torrent) GetSmartState() int {
 	defer perf.ScopeTimer()()
 
 	if t.th == nil || t.th.Swigcptr() == 0 {
-		return StatusStrings[StatusQueued], StatusQueued
+		return StatusQueued
 	}
 
 	torrentStatus := t.GetLastStatus(false)
@@ -811,25 +811,25 @@ func (t *Torrent) GetStateString() (string, int) {
 	state := int(torrentStatus.GetState())
 
 	if t.Service.Session.IsPaused() {
-		return StatusStrings[StatusPaused], StatusPaused
+		return StatusPaused
 	} else if torrentStatus.GetPaused() && state != StatusFinished && state != StatusFinding {
 		if progress == 100 {
-			return StatusStrings[StatusFinished], StatusFinished
+			return StatusFinished
 		}
 
-		return StatusStrings[StatusPaused], StatusPaused
+		return StatusPaused
 	} else if !torrentStatus.GetPaused() && (state == StatusFinished || progress == 100) {
 		if progress < 100 {
-			return StatusStrings[StatusDownloading], StatusDownloading
+			return StatusDownloading
 		}
 	} else if state != StatusQueued && t.IsBuffering {
-		return StatusStrings[StatusBuffering], StatusBuffering
+		return StatusBuffering
 	}
 	if t.IsBuffering {
-		return StatusStrings[StatusBuffering], StatusBuffering
+		return StatusBuffering
 	}
 
-	return StatusStrings[state], state
+	return state
 }
 
 // GetBufferProgress ...

--- a/bittorrent/torrent.go
+++ b/bittorrent/torrent.go
@@ -799,11 +799,11 @@ func (t *Torrent) GetState() int {
 }
 
 // GetStateString ...
-func (t *Torrent) GetStateString() string {
+func (t *Torrent) GetStateString() (string, int) {
 	defer perf.ScopeTimer()()
 
 	if t.th == nil || t.th.Swigcptr() == 0 {
-		return StatusStrings[StatusQueued]
+		return StatusStrings[StatusQueued], StatusQueued
 	}
 
 	torrentStatus := t.GetLastStatus(false)
@@ -811,25 +811,25 @@ func (t *Torrent) GetStateString() string {
 	state := int(torrentStatus.GetState())
 
 	if t.Service.Session.IsPaused() {
-		return StatusStrings[StatusPaused]
+		return StatusStrings[StatusPaused], StatusPaused
 	} else if torrentStatus.GetPaused() && state != StatusFinished && state != StatusFinding {
 		if progress == 100 {
-			return StatusStrings[StatusFinished]
+			return StatusStrings[StatusFinished], StatusFinished
 		}
 
-		return StatusStrings[StatusPaused]
+		return StatusStrings[StatusPaused], StatusPaused
 	} else if !torrentStatus.GetPaused() && (state == StatusFinished || progress == 100) {
 		if progress < 100 {
-			return StatusStrings[StatusDownloading]
+			return StatusStrings[StatusDownloading], StatusDownloading
 		}
 	} else if state != StatusQueued && t.IsBuffering {
-		return StatusStrings[StatusBuffering]
+		return StatusStrings[StatusBuffering], StatusBuffering
 	}
 	if t.IsBuffering {
-		return StatusStrings[StatusBuffering]
+		return StatusStrings[StatusBuffering], StatusBuffering
 	}
 
-	return StatusStrings[state]
+	return StatusStrings[state], state
 }
 
 // GetBufferProgress ...


### PR DESCRIPTION
example
```
[{"id":"xxx","name":"xxx.mkv","size":"1.6 GB","status":"Сидируется","status_code":5,"progress":100,"ratio":0,"time_ratio":0,"seeding_time":"12h11m4s","seed_time":43864,"seed_time_limit":864000,"download_rate":0,"upload_rate":0,"total_download":0,"total_upload":3909418211,"seeders":0,"seeders_total":303,"peers":0,"peers_total":365}]
```
for https://github.com/elgatito/plugin.video.elementum/pull/740
list of enums to use
https://github.com/elgatito/elementum/blob/dc011901ac0fb798bdc78a5be60149bf2ccf688b/bittorrent/types.go#L35-L56
