### PR TITLE
escape path for subtitles

### DIFF
--- a/bittorrent/player.go
+++ b/bittorrent/player.go
@@ -1217,12 +1217,7 @@ func (btp *Player) SetSubtitles() {
 
 		for _, f := range btp.t.files {
 			if strings.Contains(f.Path, currentPath) && util.HasSubtitlesExt(f.Path) {
-				escapedPath := f.Path
-				if u, err := url.Parse(f.Path); err == nil {
-					//if path has " " for example
-					escapedPath = u.EscapedPath()
-				}
-				collected = append(collected, util.GetHTTPHost()+"/files/"+escapedPath)
+				collected = append(collected, util.GetHTTPHost()+"/files/"+util.EncodeFileURL(f.Path))
 			}
 		}
 

--- a/bittorrent/player.go
+++ b/bittorrent/player.go
@@ -1217,7 +1217,12 @@ func (btp *Player) SetSubtitles() {
 
 		for _, f := range btp.t.files {
 			if strings.Contains(f.Path, currentPath) && util.HasSubtitlesExt(f.Path) {
-				collected = append(collected, util.GetHTTPHost()+"/files/"+f.Path)
+				escapedPath := f.Path
+				if u, err := url.Parse(f.Path); err == nil {
+					//if path has " " for example
+					escapedPath = u.EscapedPath()
+				}
+				collected = append(collected, util.GetHTTPHost()+"/files/"+escapedPath)
 			}
 		}
 


### PR DESCRIPTION
fix https://github.com/elgatito/plugin.video.elementum/issues/755

example:
https://play.golang.org/p/-vvBs_1jFvY