### PR TITLE
take addedTime from torrent file mod time and expose it via api

### DIFF
--- a/api/torrents.go
+++ b/api/torrents.go
@@ -33,6 +33,7 @@ var (
 type TorrentsWeb struct {
 	ID            string  `json:"id"`
 	Name          string  `json:"name"`
+	AddedTime     int64   `json:"added_time"`
 	Size          string  `json:"size"`
 	SizeBytes     int64   `json:"size_bytes"`
 	Status        string  `json:"status"`
@@ -329,6 +330,7 @@ func ListTorrentsWeb(s *bittorrent.Service) gin.HandlerFunc {
 			torrentStatus := t.GetLastStatus(false)
 
 			torrentName := torrentStatus.GetName()
+			addedTime := t.GetAddedTime().Unix()
 			progress := float64(torrentStatus.GetProgress()) * 100
 
 			infoHash := t.InfoHash()
@@ -365,6 +367,7 @@ func ListTorrentsWeb(s *bittorrent.Service) gin.HandlerFunc {
 			ti := &TorrentsWeb{
 				ID:            infoHash,
 				Name:          torrentName,
+				AddedTime:     addedTime,
 				Size:          size,
 				SizeBytes:     sizeBytes,
 				Status:        status,
@@ -454,7 +457,7 @@ func AddTorrent(s *bittorrent.Service) gin.HandlerFunc {
 
 		if t == nil {
 			var err error
-			t, err = s.AddTorrent(uri, false, config.Get().DownloadStorage, true)
+			t, err = s.AddTorrent(uri, false, config.Get().DownloadStorage, true, time.Now())
 			if err != nil {
 				ctx.String(404, err.Error())
 				return

--- a/bittorrent/player.go
+++ b/bittorrent/player.go
@@ -189,7 +189,7 @@ func (btp *Player) addTorrent() error {
 			storage = StorageFile
 		}
 
-		torrent, err := btp.s.AddTorrent(btp.p.URI, false, storage, true)
+		torrent, err := btp.s.AddTorrent(btp.p.URI, false, storage, true, time.Now())
 		if err != nil {
 			log.Errorf("Error adding torrent to player: %s", err)
 			return err

--- a/bittorrent/service.go
+++ b/bittorrent/service.go
@@ -634,7 +634,7 @@ func (s *Service) checkAvailableSpace(t *Torrent) bool {
 }
 
 // AddTorrent ...
-func (s *Service) AddTorrent(uri string, paused bool, downloadStorage int, firstTime bool) (*Torrent, error) {
+func (s *Service) AddTorrent(uri string, paused bool, downloadStorage int, firstTime bool, addedTime time.Time) (*Torrent, error) {
 	defer perf.ScopeTimer()()
 
 	// To make sure no spaces coming from Web UI
@@ -799,7 +799,7 @@ func (s *Service) AddTorrent(uri string, paused bool, downloadStorage int, first
 		t.MemorySize = s.GetMemorySize()
 	}
 
-	t.addedTime = time.Now()
+	t.addedTime = addedTime
 	s.q.Add(t)
 
 	if !t.HasMetadata() {
@@ -1140,7 +1140,7 @@ func (s *Service) loadTorrentFiles() {
 		filePath := filepath.Join(s.config.TorrentsPath, torrentFile.Name())
 		log.Infof("Loading torrent file %s", torrentFile.Name())
 
-		t, err := s.AddTorrent(filePath, s.config.AutoloadTorrentsPaused, StorageFile, false)
+		t, err := s.AddTorrent(filePath, s.config.AutoloadTorrentsPaused, StorageFile, false, torrentFile.ModTime())
 		if err != nil {
 			log.Warningf("Cannot add torrent from existing file %s: %s", filePath, err)
 			continue


### PR DESCRIPTION
take addedTime from torrent file mod time instead of now()
then expose it via api

for https://github.com/elgatito/plugin.video.elementum/pull/754


example:
```
$ curl -s http://192.168.31.58:65220/torrents/list | jq .[0]
{
"id": "123",
"name": "123.mkv",
"added_time": 1617699957,
"size": "1.6 GB",
"size_bytes": 1558462508,
"status": "Сидируется",
"status_code": 5,
"progress": 100,
"ratio": 0,
"time_ratio": 0,
"seeding_time": "3h32m10s",
"seed_time": 12730,
"seed_time_limit": 864000,
"download_rate": 0,
"upload_rate": 0,
"total_download": 0,
"total_upload": 368225541,
"seeders": 0,
"seeders_total": 302,
"peers": 0,
"peers_total": 352
}
```