### PR TITLE
fix concurrent map writes on pendingShows

### DIFF
--- a/library/library.go
+++ b/library/library.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/anacrolix/missinggo/perf"
@@ -105,6 +106,8 @@ var (
 	resolveRegexp = regexp.MustCompile(`^plugin://plugin.video.elementum.*?(\d+)(\W|$)`)
 
 	pendingShows = map[int]bool{}
+
+	lock = sync.Mutex{}
 )
 
 var l = &Library{

--- a/library/refresh.go
+++ b/library/refresh.go
@@ -976,6 +976,8 @@ func PlanShowsUpdate() {
 
 // PlanShowUpdate ...
 func PlanShowUpdate(showID int) {
+	lock.Lock()
 	pendingShows[showID] = true
+	lock.Unlock()
 	l.Pending.IsEpisodes = true
 }


### PR DESCRIPTION
```
2021-05-23 21:58:36.071 T:1261096 WARNING <general>: [plugin.video.elementum] [36mDEBU  main         ▶ Notification     [0mGot notification from xbmc/VideoLibrary.OnUpdate: {"item":{"id":2014,"type":"episode"},"playcount":1}
2021-05-23 21:58:36.085 T:1261096 WARNING <general>: [plugin.video.elementum] [36mDEBU  main         ▶ Notification     [0mGot notification from xbmc/VideoLibrary.OnUpdate: {"item":{"id":2015,"type":"episode"},"playcount":1}
2021-05-23 21:58:36.094 T:1261056 WARNING <general>: CGUIMediaWindow::OnMessage - updating in progress
2021-05-23 21:58:36.098 T:1261096 WARNING <general>: Skipped 1 duplicate messages..
2021-05-23 21:58:36.098 T:1261096 WARNING <general>: [plugin.video.elementum] [36mDEBU  main         ▶ Notification     [0mGot notification from xbmc/VideoLibrary.OnUpdate: {"item":{"id":2016,"type":"episode"},"playcount":1}
2021-05-23 21:58:36.103 T:1261096 WARNING <general>: [plugin.video.elementum] fatal error: concurrent map writes
2021-05-23 21:58:36.106 T:1261096 WARNING <general>: [plugin.video.elementum] 
2021-05-23 21:58:36.106 T:1261096 WARNING <general>: [plugin.video.elementum] goroutine 478 [running]:
2021-05-23 21:58:36.106 T:1261096 WARNING <general>: [plugin.video.elementum] runtime.throw(0x166c903, 0x15)
2021-05-23 21:58:36.107 T:1261096 WARNING <general>: [plugin.video.elementum] 	/usr/x86_64-linux-gnu/go/src/runtime/panic.go:1117 +0x72 fp=0xc0005556e8 sp=0xc0005556b8 pc=0x560bf2
2021-05-23 21:58:36.107 T:1261096 WARNING <general>: [plugin.video.elementum] runtime.mapassign_fast64(0x1547820, 0xc0004ae300, 0x3b, 0x0)
2021-05-23 21:58:36.107 T:1261096 WARNING <general>: [plugin.video.elementum] 	/usr/x86_64-linux-gnu/go/src/runtime/map_fast64.go:176 +0x325 fp=0xc000555728 sp=0xc0005556e8 pc=0x53b865
2021-05-23 21:58:36.107 T:1261096 WARNING <general>: [plugin.video.elementum] github.com/elgatito/elementum/library.PlanShowUpdate(...)
2021-05-23 21:58:36.107 T:1261096 WARNING <general>: [plugin.video.elementum] 	/go/src/github.com/elgatito/elementum/library/refresh.go:979
2021-05-23 21:58:36.107 T:1261096 WARNING <general>: [plugin.video.elementum] github.com/elgatito/elementum/library.RefreshEpisode(0x7de, 0x0)
2021-05-23 21:58:36.107 T:1261096 WARNING <general>: [plugin.video.elementum] 	/go/src/github.com/elgatito/elementum/library/refresh.go:461 +0x9c fp=0xc0005557b8 sp=0xc000555728 pc=0xe637fc
2021-05-23 21:58:36.107 T:1261096 WARNING <general>: [plugin.video.elementum] main.Notification.func3(0xc0000ad560)
2021-05-23 21:58:36.107 T:1261096 WARNING <general>: [plugin.video.elementum] 	/go/src/github.com/elgatito/elementum/maintenance.go:247 +0xbb fp=0xc0005557d8 sp=0xc0005557b8 pc=0xf8739b
2021-05-23 21:58:36.107 T:1261096 WARNING <general>: [plugin.video.elementum] runtime.goexit()
2021-05-23 21:58:36.107 T:1261096 WARNING <general>: [plugin.video.elementum] 	/usr/x86_64-linux-gnu/go/src/runtime/asm_amd64.s:1371 +0x1 fp=0xc0005557e0 sp=0xc0005557d8 pc=0x59af81
2021-05-23 21:58:36.108 T:1261096 WARNING <general>: [plugin.video.elementum] created by main.Notification
2021-05-23 21:58:36.108 T:1261096 WARNING <general>: [plugin.video.elementum] 	/go/src/github.com/elgatito/elementum/maintenance.go:232 +0x1230
2021-05-23 21:58:36.111 T:1261096 WARNING <general>: [plugin.video.elementum] 
2021-05-23 21:58:36.111 T:1261096 WARNING <general>: [plugin.video.elementum] goroutine 1 [IO wait]:
2021-05-23 21:58:36.111 T:1261096 WARNING <general>: [plugin.video.elementum] internal/poll.runtime_pollWait(0x7f9bd04ff7d8, 0x72, 0x0)
2021-05-23 21:58:36.112 T:1261096 WARNING <general>: [plugin.video.elementum] 	/usr/x86_64-linux-gnu/go/src/runtime/netpoll.go:222 +0x55
2021-05-23 21:58:36.112 T:1261096 WARNING <general>: [plugin.video.elementum] System information: linux_x64 
2021-05-23 21:58:36.112 T:1261096 WARNING <general>: [plugin.video.elementum] Kodi build version: 19.1 (19.1.0) Git:20210509-85e05228b4
2021-05-23 21:58:36.112 T:1261096 WARNING <general>: [plugin.video.elementum] OS type: Linux
2021-05-23 21:58:36.112 T:1261096 WARNING <general>: [plugin.video.elementum] uname: uname_result(system='Linux', node='antix-pc', release='5.11.0-17-generic', version='#18-Ubuntu SMP Thu May 6 20:10:11 UTC 2021', machine='x86_64')
2021-05-23 21:58:41.118 T:1261096 WARNING <general>: [plugin.video.elementum] elementumd: starting elementumd
```