### PR TITLE
fix panic in renderCalendarShows

### DIFF
--- a/api/trakt.go
+++ b/api/trakt.go
@@ -1185,7 +1185,11 @@ func renderCalendarShows(ctx *gin.Context, shows []*trakt.CalendarShow, total in
 
 			if !config.Get().ForceUseTrakt && showListing.Show.IDs.TMDB != 0 {
 				show = tmdb.GetShow(showListing.Show.IDs.TMDB, language)
-				season = tmdb.GetSeason(showListing.Show.IDs.TMDB, epi.Season, language, len(show.Seasons))
+				seasonsCount := 0
+				if show != nil {
+					seasonsCount = len(show.Seasons)
+				}
+				season = tmdb.GetSeason(showListing.Show.IDs.TMDB, epi.Season, language, seasonsCount)
 				episode = tmdb.GetEpisode(showListing.Show.IDs.TMDB, epi.Season, epi.Number, language)
 
 				if episode != nil {


### PR DESCRIPTION
shows->calendar->all shows->panic

```
2021-05-23 22:18:41.936 T:1261096 WARNING <general>: [plugin.video.elementum] panic: runtime error: invalid memory address or nil pointer dereference
2021-05-23 22:18:41.936 T:1261096 WARNING <general>: [plugin.video.elementum] [signal SIGSEGV: segmentation violation code=0x1 addr=0x1f0 pc=0xf7dfbf]
2021-05-23 22:18:41.936 T:1261096 WARNING <general>: [plugin.video.elementum] 
2021-05-23 22:18:41.937 T:1261096 WARNING <general>: [plugin.video.elementum] goroutine 17364 [running]:
2021-05-23 22:18:41.937 T:1261096 WARNING <general>: [plugin.video.elementum] github.com/elgatito/elementum/api.renderCalendarShows.func1(0xc000a16340, 0xc0005b8358, 0x2, 0xc0004070b4, 0x7, 0x0, 0xed83b9200, 0x0, 0xc0004070c0, 0x8, ...) 
2021-05-23 22:18:42.003 T:1261096 WARNING <general>: [plugin.video.elementum]   /go/src/github.com/elgatito/elementum/api/trakt.go:1188 +0x213f
```