### PR TITLE
added support of hidden shows

### DIFF
--- a/cache/types.go
+++ b/cache/types.go
@@ -99,6 +99,8 @@ const (
 	TraktShowsCalendarExpire               = GeneralExpire
 	TraktShowsCalendarTotalKey             = TraktKey + "shows.calendar.%s.total"
 	TraktShowsCalendarTotalExpire          = GeneralExpire
+	TraktShowsHiddenProgressKey            = TraktKey + "shows.hidden.progress"
+	TraktShowsHiddenProgressExpire         = GeneralExpire
 	TraktSeasonKey                         = TraktKey + "season.%d.%d"
 	TraktSeasonExpire                      = GeneralExpire
 	TraktEpisodeKey                        = TraktKey + "episode.%d.%d.%d"

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -762,7 +762,6 @@ func WatchedShowsProgress() (shows []*ProgressShow, err error) {
 	}
 	wg.Wait()
 
-	// first approach
 	hiddenShowsMap := GetHiddenShowsMap("progress_watched")
 	for _, s := range showsList {
 		if s != nil {
@@ -773,9 +772,6 @@ func WatchedShowsProgress() (shows []*ProgressShow, err error) {
 			}
 		}
 	}
-
-	// second approach
-	//shows = FilterHiddenProgressShows(showsList)
 
 	return
 }
@@ -797,15 +793,11 @@ func GetHiddenShowsMap(section string) map[int]bool {
 
 // FilterHiddenProgressShows returns a slice of ProgressShow without hidden shows
 func FilterHiddenProgressShows(inShows []*ProgressShow) (outShows []*ProgressShow) {
-	hiddenShowsMap := make(map[int]bool)
 	if config.Get().TraktToken == "" || !config.Get().TraktSyncHidden {
 		return inShows
 	}
 
-	hiddenShowsProgress, _ := ListHiddenShows("progress_watched", false)
-	for _, show := range hiddenShowsProgress {
-		hiddenShowsMap[show.Show.IDs.Trakt] = true
-	}
+	hiddenShowsMap := GetHiddenShowsMap("progress_watched")
 
 	for _, s := range inShows {
 		if s != nil {

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -763,11 +763,91 @@ func WatchedShowsProgress() (shows []*ProgressShow, err error) {
 	wg.Wait()
 
 	for _, s := range showsList {
-		if s != nil {
+		if s != nil && !ShowIsHidden("progress_watched", s.Show.IDs.Trakt) {
 			shows = append(shows, s)
 		}
 	}
 
+	return
+}
+
+// ShowIsHidden ...
+func ShowIsHidden(section string, traktID int) bool {
+	if config.Get().TraktToken == "" || !config.Get().TraktSyncHidden {
+		return false
+	}
+
+	hiddenShowsProgress, _ := ListHiddenShows(section, false)
+	for _, show := range hiddenShowsProgress {
+		if show.Show.IDs.Trakt == traktID {
+			log.Debugf("Found hidden show: %s", show.Show.Title)
+			return true
+		}
+	}
+
+	return false
+}
+
+// ListHiddenShows updates list of hidden shows for a given section
+func ListHiddenShows(section string, isUpdateNeeded bool) (shows []*Shows, err error) {
+	if err := Authorized(); err != nil {
+		return shows, err
+	}
+
+	endPoint := "users/hidden/" + section
+
+	params := napping.Params{
+		"type":  "show",
+		"limit": "100",
+	}.AsUrlValues()
+
+	cacheStore := cache.NewDBStore()
+	var cacheKey string
+	var cacheExpiration time.Duration
+	switch section {
+	case "progress_watched":
+		cacheKey = cache.TraktShowsHiddenProgressKey
+		cacheExpiration = cache.TraktShowsHiddenProgressExpire
+	default:
+		return shows, fmt.Errorf("Unsupported section for hidden shows: %s", section)
+	}
+
+	if !isUpdateNeeded {
+		if err := cacheStore.Get(cacheKey, &shows); err == nil {
+			return shows, nil
+		}
+	}
+
+	totalPages := 1
+	for page := 1; page < totalPages+1; page++ {
+		params.Add("page", strconv.Itoa(page))
+
+		resp, err := GetWithAuth(endPoint, params)
+
+		if err != nil {
+			return shows, err
+		} else if resp.Status() != 200 {
+			log.Error(err)
+			return shows, fmt.Errorf("Bad status getting Trakt hidden items for shows: %d", resp.Status())
+		}
+
+		var hiddenShows []*HiddenShow
+		if err := resp.Unmarshal(&hiddenShows); err != nil {
+			log.Warning(err)
+		}
+
+		for _, show := range hiddenShows {
+			showItem := Shows{
+				Show: show.Show,
+			}
+			shows = append(shows, &showItem)
+		}
+
+		pagination := getPagination(resp.HttpResponse().Header)
+		totalPages = pagination.PageCount
+	}
+
+	cacheStore.Set(cacheKey, &shows, cacheExpiration)
 	return
 }
 

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -254,6 +254,13 @@ type CollectedEpisode struct {
 	Number      int    `json:"number"`
 }
 
+// HiddenShow ...
+type HiddenShow struct {
+	HiddenAt string `json:"hidden_at"`
+	Type     string `json:"type"`
+	Show     *Show  `json:"show"`
+}
+
 // Images ...
 type Images struct {
 	Poster     *Sizes `json:"poster"`


### PR DESCRIPTION
https://trakt.docs.apiary.io/#reference/users/hidden-items/get-hidden-items

calendar and recommendations for shows are handled on trakt side, progress_watched should be handled manually.

calendar and recommendations for movies are handled on trakt side, and they are the only options.

looks like website does not allow to hide seasons, so we also can ignore them.

fix https://github.com/elgatito/plugin.video.elementum/issues/290