### PR TITLE
hide trakt tokens in log

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,7 @@ import (
 )
 
 var log = logging.MustGetLogger("config")
-var privacyRegex = regexp.MustCompile(`(?i)(pass|password): "(.+?)"`)
+var privacyRegex = regexp.MustCompile(`(?i)(pass|password|token): "(.+?)"`)
 
 const (
 	maxMemorySize                = 300 * 1024 * 1024


### PR DESCRIPTION
example:
```
2021-06-05 21:38:31.635 T:481327 WARNING <general>: [plugin.video.elementum]   TraktToken: "********",
2021-06-05 21:38:31.635 T:481327 WARNING <general>: [plugin.video.elementum]   TraktRefreshToken: "********",
```
