### PR TITLE
try to speed-up ShowUnwatchedEpisodesNumber with trakt as a source for shows info

### DIFF
--- a/cache/types.go
+++ b/cache/types.go
@@ -103,6 +103,8 @@ const (
 	TraktShowsHiddenProgressExpire         = GeneralExpire
 	TraktSeasonsKey                        = TraktKey + "seasons.%d"
 	TraktSeasonsExpire                     = GeneralExpire
+	TraktSeasonsExtendedKey                = TraktKey + "seasons.%d.extended"
+	TraktSeasonsExtendedExpire             = GeneralExpire
 	TraktSeasonKey                         = TraktKey + "season.%d.%d"
 	TraktSeasonExpire                      = GeneralExpire
 	TraktEpisodeKey                        = TraktKey + "episode.%d.%d.%d"

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -150,8 +150,9 @@ type Season struct {
 	Votes         int     `json:"votes"`
 	Network       string  `json:"network"`
 
-	Images *Images `json:"images"`
-	IDs    *IDs    `json:"ids"`
+	Episodes []*Episode `json:"episodes"`
+	Images   *Images    `json:"images"`
+	IDs      *IDs       `json:"ids"`
 }
 
 // Episode ...


### PR DESCRIPTION
https://trakt.tv/users/justin/lists/trakt-popular-tv-shows?sort=rank,asc

без кол-ва сезонов - 1с (так было раньше)
с кол-вом сезонов - 20с

с эпизодами по старому - 100с
с эпизодами по новому - 40с

в любом случае медленно даже с фиксом, так что я перенёс кол-во сезонов тоже в ShowUnwatchedEpisodesNumber.
лучше быстро, чем с минимальной доп инфой.

соотв если ShowUnwatchedEpisodesNumber не включен - 1с (вместо 20с)
если включен - 40с (вместо 100с) - так сказать на свой страх и риск.

плюс добавил CountRealSeasons.