### PR TITLE
avoid leakage if a proxy is defined

### DIFF
--- a/bittorrent/service.go
+++ b/bittorrent/service.go
@@ -382,6 +382,9 @@ func (s *Service) configure() {
 
 		// Proxy Tracker connections
 		settings.SetBool("proxy_tracker_connections", config.Get().ProxyUseTracker)
+		
+		// ensure no leakage
+		settings.SetBool("force_proxy", true)
 	}
 
 	// Set alert_mask here so it also applies on reconfigure...


### PR DESCRIPTION
In few cases, libtorrent, even configured to use a proxy, goes straight : it leaks real IP and try to reach outside directly.

it can be manually set in libtorrent.config too.
force_proxy=true

By placing this line, if the user has set a proxy : it's safest