### PR TITLE
reduce log - state_changed_alert & torrent_finished_alert

### DIFF
--- a/bittorrent/service.go
+++ b/bittorrent/service.go
@@ -1143,7 +1143,11 @@ func (s *Service) logAlerts() {
 		} else if alert.Category&int(lt.AlertPerformanceWarning) != 0 {
 			log.Warningf("%s: %s", alert.What, alert.Message)
 		} else {
-			log.Noticef("%s: %s", alert.What, alert.Message)
+			if alert.What != "state_changed_alert" {
+				if alert.What != "torrent_finished_alert" {
+					log.Noticef("%s: %s", alert.What, alert.Message)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This patch reduce log : those two lines are spamming a lot.