### PR TITLE
Set peer_fingerprint to make SpoofUserAgent work

### DIFF
--- a/bittorrent/service.go
+++ b/bittorrent/service.go
@@ -209,6 +209,7 @@ func (s *Service) configure() {
 	s.PeerID, s.UserAgent = ident.GetUserAndPeer()
 	log.Infof("UserAgent: %s, PeerID: %s", s.UserAgent, s.PeerID)
 	settings.SetStr("user_agent", s.UserAgent)
+	settings.SetStr("peer_fingerprint", s.PeerID)
 
 	// Bools
 	settings.SetBool("announce_to_all_tiers", true)


### PR DESCRIPTION
Looks like we also need to set `peer_fingerprint` (https://libtorrent.org/reference-Settings.html ) in order to make `SpoofUserAgent` option work.
Fixes https://github.com/elgatito/plugin.video.elementum/issues/884


before fix:
`2023-11-29 00:03:28.854 T:427837 warning <general>: [plugin.video.elementum] NOTI  bittorrent   ▶ logAlerts        peer_log_alert: X.mkv [46.191.138.15:37948] >>> HANDSHAKE [ sent peer_id: X client: libtorrent 1.1.14 ]`
`2023-11-29 00:03:29.768 T:427837 warning <general>: [plugin.video.elementum] NOTI  bittorrent   ▶ logAlerts        torrent_log_alert: X.mkv: ==> TRACKER_REQUEST [ url: http://bt4.t-ru.org/ann?info_hash=X&peer_id=-LT11E0-Z4NXXX&port=6898&uploaded=0&downloaded=1569766818&left=0&corrupt=0&key=X&event=stopped&numwant=0&compact=1&no_peer_id=1&supportcrypto=1&redundant=9585714 ]`
after fix:
`2023-11-29 00:22:25.121 T:463598 warning <general>: [plugin.video.elementum] NOTI  bittorrent   ▶ logAlerts        peer_log_alert: X.mkv [85.15.95.111:56792] >>> HANDSHAKE [ sent peer_id: X client: Transmission 2.9.2 ]`
`2023-11-29 00:22:25.136 T:463598 warning <general>: [plugin.video.elementum] NOTI  bittorrent   ▶ logAlerts        torrent_log_alert: X.mkv: ==> TRACKER_REQUEST [ url: http://bt4.t-ru.org/ann?info_hash=X&peer_id=-TR2920-3(-~sUZXXX&port=6895&uploaded=0&downloaded=1569766818&left=0&corrupt=0&key=X&event=stopped&numwant=0&compact=1&no_peer_id=1&supportcrypto=1&redundant=8171523 ]`

(for test agent was set to https://github.com/elgatito/elementum/blob/3056084780529a8bab9327861ef4b804d4716def/util/ident/ident.go#L106-L107)