### PR TITLE
Fixes for countWatchedEpisodesNumber

### DIFF
--- a/tmdb/season.go
+++ b/tmdb/season.go
@@ -309,14 +309,17 @@ func (season *Season) findTranslation(language string) *Translation {
 }
 
 // countWatchedEpisodesNumber returns number of watched episodes
-func (season *Season) countWatchedEpisodesNumber(show *Show) int {
+func (season *Season) countWatchedEpisodesNumber(show *Show) (watchedEpisodes int) {
 	if show == nil {
-		return 0
+		return
 	}
 
 	c := config.Get()
 
-	watchedEpisodes := 0
+	if !c.ShowSeasonsSpecials && season.Season <= 0 {
+		return
+	}
+
 	if playcount.GetWatchedSeasonByTMDB(show.ID, season.Season) {
 		watchedEpisodes += season.EpisodeCount
 	} else {
@@ -337,7 +340,7 @@ func (season *Season) countWatchedEpisodesNumber(show *Show) int {
 			}
 		}
 	}
-	return watchedEpisodes
+	return
 }
 
 // countEpisodesNumber returns number of episodes
@@ -347,6 +350,10 @@ func (season *Season) countEpisodesNumber(show *Show) (episodes int) {
 	}
 
 	c := config.Get()
+
+	if !c.ShowSeasonsSpecials && season.Season <= 0 {
+		return
+	}
 
 	for _, episode := range season.Episodes {
 		if episode == nil {

--- a/tmdb/show.go
+++ b/tmdb/show.go
@@ -724,29 +724,26 @@ func (show *Show) findTranslation(language string) *Translation {
 }
 
 // countWatchedEpisodesNumber returns number of watched episodes
-func (show *Show) countWatchedEpisodesNumber() int {
-	watchedEpisodes := 0
+func (show *Show) countWatchedEpisodesNumber() (watchedEpisodes int) {
 	if playcount.GetWatchedShowByTMDB(show.ID) {
 		watchedEpisodes = show.NumberOfEpisodes
 	} else {
-		if show.Seasons == nil {
-			return 0
-		}
-
 		for _, season := range show.Seasons {
+			if season == nil {
+				return
+			}
 			watchedEpisodes += season.countWatchedEpisodesNumber(show)
 		}
 	}
-	return watchedEpisodes
+	return
 }
 
 // countEpisodesNumber returns number of episodes taking into account unaired and special
 func (show *Show) countEpisodesNumber() (episodes int) {
-	if show.Seasons == nil {
-		return
-	}
-
 	for _, season := range show.Seasons {
+		if season == nil {
+			return
+		}
 		episodes += season.countEpisodesNumber(show)
 	}
 

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -147,6 +147,7 @@ type Season struct {
 	Overview      string  `json:"overview"`
 	EpisodeCount  int     `json:"episode_count"`
 	AiredEpisodes int     `json:"aired_episodes"`
+	FirstAired    string  `json:"first_aired"`
 	Rating        float32 `json:"rating"`
 	Votes         int     `json:"votes"`
 	Network       string  `json:"network"`


### PR DESCRIPTION
Fixes for for https://github.com/elgatito/plugin.video.elementum/issues/834

1. Use ShowSeasonsSpecials for counting in TMDB - у меня общее число иначе больше на кол-во спец эпизодов.

2. TMDB show.Seasons: ok to range over nil, but not ok to use nil items.

т.е. мы проверяли что slice == nil, но для списка мы не используем методы (a range работает для nil slice), соотв ничего не упадёт, а вот внутри могут быть элементы nil и для них мы используем их методы и тут может упасть.

вот упрощенные примеры:
https://go.dev/play/p/t9Kdq8r7-FN

3. Trakt: use ShowSeasonsSpecials & ShowUnairedEpisodes for counting

