### PR TITLE
Add countEpisodesNumber to Trakt show

### DIFF
--- a/api/shows.go
+++ b/api/shows.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/anacrolix/missinggo/perf"
 	"github.com/anacrolix/sync"
@@ -577,7 +578,7 @@ func ShowEpisodes(ctx *gin.Context) {
 				continue
 			}
 			if !config.Get().ShowUnairedSeasons {
-				if _, isExpired := util.AirDateWithExpireCheck(s.AirDate, config.Get().ShowEpisodesOnReleaseDay); isExpired {
+				if _, isExpired := util.AirDateWithExpireCheck(s.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); isExpired {
 					continue
 				}
 			}

--- a/api/trakt.go
+++ b/api/trakt.go
@@ -1565,6 +1565,7 @@ func renderProgressShows(ctx *gin.Context, shows []*trakt.ProgressShow, total in
 			episodeNumber := epi.Number
 			episodeName := epi.Title
 			showName := showListing.Show.Title
+			airDateFormat := time.DateOnly
 
 			var episode *tmdb.Episode
 			var season *tmdb.Season
@@ -1591,13 +1592,14 @@ func renderProgressShows(ctx *gin.Context, shows []*trakt.ProgressShow, total in
 				episodes := trakt.GetSeasonEpisodes(showListing.Show.IDs.Trakt, seasonNumber)
 				for _, e := range episodes {
 					if e != nil && e.Number == epi.Number && strings.Contains(e.FirstAired, "T") {
-						airDate = e.FirstAired[0:strings.Index(e.FirstAired, "T")]
+						airDate = e.FirstAired
+						airDateFormat = time.RFC3339
 						break
 					}
 				}
 			}
 
-			aired, isExpired := util.AirDateWithExpireCheck(airDate, config.Get().ShowEpisodesOnReleaseDay)
+			aired, isExpired := util.AirDateWithExpireCheck(airDate, airDateFormat, config.Get().ShowEpisodesOnReleaseDay)
 			if config.Get().TraktProgressUnaired && isExpired {
 				return
 			}

--- a/library/library.go
+++ b/library/library.go
@@ -576,7 +576,7 @@ func writeShowStrm(showID int, adding, force bool) (*tmdb.Show, error) {
 			continue
 		}
 		if !config.Get().ShowUnairedSeasons {
-			if _, isExpired := util.AirDateWithExpireCheck(season.AirDate, config.Get().ShowEpisodesOnReleaseDay); isExpired {
+			if _, isExpired := util.AirDateWithExpireCheck(season.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); isExpired {
 				continue
 			}
 		}
@@ -600,7 +600,7 @@ func writeShowStrm(showID int, adding, force bool) (*tmdb.Show, error) {
 				if episode.AirDate == "" {
 					continue
 				}
-				if _, isExpired := util.AirDateWithExpireCheck(episode.AirDate, config.Get().ShowEpisodesOnReleaseDay); isExpired {
+				if _, isExpired := util.AirDateWithExpireCheck(episode.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); isExpired {
 					continue
 				}
 			}

--- a/tmdb/episode.go
+++ b/tmdb/episode.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/anacrolix/missinggo/perf"
 
@@ -68,7 +69,7 @@ func (episodes EpisodeList) ToListItems(show *Show, season *Season) []*xbmc.List
 			if episode.AirDate == "" {
 				continue
 			}
-			if _, isExpired := util.AirDateWithExpireCheck(episode.AirDate, config.Get().ShowEpisodesOnReleaseDay); isExpired {
+			if _, isExpired := util.AirDateWithExpireCheck(episode.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); isExpired {
 				continue
 			}
 		}

--- a/tmdb/season.go
+++ b/tmdb/season.go
@@ -169,7 +169,9 @@ func (season *Season) ToListItem(show *Show) *xbmc.ListItem {
 		name = "Specials"
 	}
 
-	season.EpisodeCount = season.countEpisodesNumber(show)
+	if config.Get().ShowUnwatchedEpisodesNumber {
+		season.EpisodeCount = season.countEpisodesNumber()
+	}
 
 	item := &xbmc.ListItem{
 		Label: name,
@@ -344,8 +346,8 @@ func (season *Season) countWatchedEpisodesNumber(show *Show) (watchedEpisodes in
 }
 
 // countEpisodesNumber returns number of episodes
-func (season *Season) countEpisodesNumber(show *Show) (episodes int) {
-	if show == nil || season.Episodes == nil {
+func (season *Season) countEpisodesNumber() (episodes int) {
+	if season.Episodes == nil {
 		return season.EpisodeCount
 	}
 

--- a/tmdb/season.go
+++ b/tmdb/season.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/elgatito/elementum/cache"
 	"github.com/elgatito/elementum/config"
@@ -131,7 +132,7 @@ func (seasons SeasonList) ToListItems(show *Show) []*xbmc.ListItem {
 		}
 
 		if !config.Get().ShowUnairedSeasons {
-			if _, isExpired := util.AirDateWithExpireCheck(season.AirDate, config.Get().ShowEpisodesOnReleaseDay); isExpired {
+			if _, isExpired := util.AirDateWithExpireCheck(season.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); isExpired {
 				continue
 			}
 		}
@@ -332,7 +333,7 @@ func (season *Season) countWatchedEpisodesNumber(show *Show) (watchedEpisodes in
 				if episode.AirDate == "" {
 					continue
 				}
-				if _, isExpired := util.AirDateWithExpireCheck(episode.AirDate, c.ShowEpisodesOnReleaseDay); isExpired {
+				if _, isExpired := util.AirDateWithExpireCheck(episode.AirDate, time.DateOnly, c.ShowEpisodesOnReleaseDay); isExpired {
 					continue
 				}
 			}
@@ -364,7 +365,7 @@ func (season *Season) countEpisodesNumber() (episodes int) {
 			if episode.AirDate == "" {
 				continue
 			}
-			if _, isExpired := util.AirDateWithExpireCheck(episode.AirDate, c.ShowEpisodesOnReleaseDay); isExpired {
+			if _, isExpired := util.AirDateWithExpireCheck(episode.AirDate, time.DateOnly, c.ShowEpisodesOnReleaseDay); isExpired {
 				continue
 			}
 		}

--- a/tmdb/show.go
+++ b/tmdb/show.go
@@ -744,7 +744,7 @@ func (show *Show) countEpisodesNumber() (episodes int) {
 		if season == nil {
 			continue
 		}
-		episodes += season.countEpisodesNumber(show)
+		episodes += season.countEpisodesNumber()
 	}
 
 	return

--- a/tmdb/tmdb.go
+++ b/tmdb/tmdb.go
@@ -730,7 +730,7 @@ func (show *Show) CountRealSeasons() int {
 	ret := 0
 	for _, s := range show.Seasons {
 		if !c.ShowUnairedSeasons {
-			if _, isExpired := util.AirDateWithExpireCheck(s.AirDate, c.ShowEpisodesOnReleaseDay); isExpired {
+			if _, isExpired := util.AirDateWithExpireCheck(s.AirDate, time.DateOnly, c.ShowEpisodesOnReleaseDay); isExpired {
 				continue
 			}
 		}

--- a/tmdb/tmdb.go
+++ b/tmdb/tmdb.go
@@ -725,14 +725,16 @@ func (show *Show) CountRealSeasons() int {
 		return 0
 	}
 
+	c := config.Get()
+
 	ret := 0
 	for _, s := range show.Seasons {
-		if !config.Get().ShowUnairedSeasons {
-			if _, isExpired := util.AirDateWithExpireCheck(s.AirDate, config.Get().ShowEpisodesOnReleaseDay); isExpired {
+		if !c.ShowUnairedSeasons {
+			if _, isExpired := util.AirDateWithExpireCheck(s.AirDate, c.ShowEpisodesOnReleaseDay); isExpired {
 				continue
 			}
 		}
-		if !config.Get().ShowSeasonsSpecials && s.Season <= 0 {
+		if !c.ShowSeasonsSpecials && s.Season <= 0 {
 			continue
 		}
 

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -1198,15 +1198,15 @@ func (show *Show) countEpisodesNumber() (episodes int) {
 		if season == nil {
 			continue
 		}
-		episodes += season.countEpisodesNumber(show)
+		episodes += season.countEpisodesNumber()
 	}
 
 	return
 }
 
 // countEpisodesNumber returns number of episodes
-func (season *Season) countEpisodesNumber(show *Show) (episodes int) {
-	if show == nil || season.Episodes == nil {
+func (season *Season) countEpisodesNumber() (episodes int) {
+	if season.Episodes == nil {
 		return season.EpisodeCount
 	}
 

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -1151,7 +1151,7 @@ func (show *Show) countWatchedEpisodesNumber() (watchedEpisodes int) {
 						if episode.FirstAired == "" {
 							continue
 						}
-						if _, isExpired := util.AirDateWithExpireCheck(episode.FirstAired, c.ShowEpisodesOnReleaseDay); isExpired {
+						if _, isExpired := util.AirDateWithExpireCheck(episode.FirstAired, time.RFC3339, c.ShowEpisodesOnReleaseDay); isExpired {
 							continue
 						}
 					}
@@ -1178,7 +1178,7 @@ func (show *Show) CountRealSeasons() int {
 	ret := 0
 	for _, s := range seasons {
 		if !c.ShowUnairedSeasons {
-			if _, isExpired := util.AirDateWithExpireCheck(s.FirstAired, c.ShowEpisodesOnReleaseDay); isExpired {
+			if _, isExpired := util.AirDateWithExpireCheck(s.FirstAired, time.RFC3339, c.ShowEpisodesOnReleaseDay); isExpired {
 				continue
 			}
 		}
@@ -1223,7 +1223,7 @@ func (season *Season) countEpisodesNumber() (episodes int) {
 			if episode.FirstAired == "" {
 				continue
 			}
-			if _, isExpired := util.AirDateWithExpireCheck(episode.FirstAired, c.ShowEpisodesOnReleaseDay); isExpired {
+			if _, isExpired := util.AirDateWithExpireCheck(episode.FirstAired, time.RFC3339, c.ShowEpisodesOnReleaseDay); isExpired {
 				continue
 			}
 		}

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -1022,12 +1022,14 @@ func (show *Show) ToListItem() (item *xbmc.ListItem) {
 	}
 
 	if config.Get().ShowUnwatchedEpisodesNumber && config.Get().ForceUseTrakt {
-		seasons := GetSeasons(show.IDs.Trakt, false)
-		item.Properties.TotalSeasons = strconv.Itoa(CountRealSeasons(seasons))
+		item.Properties.TotalSeasons = strconv.Itoa(show.CountRealSeasons())
+
+		airedEpisodes := show.countEpisodesNumber()
+		item.Properties.TotalEpisodes = strconv.Itoa(airedEpisodes)
 
 		watchedEpisodes := show.countWatchedEpisodesNumber()
 		item.Properties.WatchedEpisodes = strconv.Itoa(watchedEpisodes)
-		item.Properties.UnWatchedEpisodes = strconv.Itoa(show.AiredEpisodes - watchedEpisodes)
+		item.Properties.UnWatchedEpisodes = strconv.Itoa(airedEpisodes - watchedEpisodes)
 	}
 
 	item.Thumbnail = item.Art.Poster
@@ -1165,7 +1167,8 @@ func (show *Show) countWatchedEpisodesNumber() (watchedEpisodes int) {
 }
 
 // CountRealSeasons counts real seasons, meaning without specials.
-func CountRealSeasons(seasons []*Season) int {
+func (show *Show) CountRealSeasons() int {
+	seasons := GetSeasons(show.IDs.Trakt, false)
 	if len(seasons) <= 0 {
 		return 0
 	}
@@ -1186,4 +1189,46 @@ func CountRealSeasons(seasons []*Season) int {
 		ret++
 	}
 	return ret
+}
+
+// countEpisodesNumber returns number of episodes taking into account unaired and special
+func (show *Show) countEpisodesNumber() (episodes int) {
+	seasons := GetSeasons(show.IDs.Trakt, true)
+	for _, season := range seasons {
+		if season == nil {
+			continue
+		}
+		episodes += season.countEpisodesNumber(show)
+	}
+
+	return
+}
+
+// countEpisodesNumber returns number of episodes
+func (season *Season) countEpisodesNumber(show *Show) (episodes int) {
+	if show == nil || season.Episodes == nil {
+		return season.EpisodeCount
+	}
+
+	c := config.Get()
+
+	if !c.ShowSeasonsSpecials && season.Number <= 0 {
+		return
+	}
+
+	for _, episode := range season.Episodes {
+		if episode == nil {
+			continue
+		} else if !c.ShowUnairedEpisodes {
+			if episode.FirstAired == "" {
+				continue
+			}
+			if _, isExpired := util.AirDateWithExpireCheck(episode.FirstAired, c.ShowEpisodesOnReleaseDay); isExpired {
+				continue
+			}
+		}
+
+		episodes++
+	}
+	return
 }

--- a/util/time.go
+++ b/util/time.go
@@ -35,8 +35,8 @@ func UTCBod() time.Time {
 	return time.Date(year, month, day, 0, 0, 0, 0, t.Location())
 }
 
-func AirDateWithExpireCheck(dt string, allowSameDay bool) (time.Time, bool) {
-	aired, _ := time.Parse("2006-01-02", dt)
+func AirDateWithExpireCheck(dt string, dateFormat string, allowSameDay bool) (time.Time, bool) {
+	aired, _ := time.Parse(dateFormat, dt)
 	now := UTCBod()
 	if aired.After(now) || (!allowSameDay && aired.Equal(now)) {
 		return aired, true


### PR DESCRIPTION
for https://github.com/elgatito/plugin.video.elementum/issues/834

manually count number of episodes, so we would not use stale `aired_episodes` field from cache of "list of shows" (like https://trakt.docs.apiary.io/#reference/users/list-items/get-items-on-a-personal-list?console=1 ) that we update only after 1 week.

also explicitly set date format for tmdb and trakt, otherwise it does not work for trakt. https://go.dev/play/p/rjuwZQNeVjm