### PR TITLE
Sync trakt lists even if Kodi library integration is disabled

### DIFF
--- a/library/trakt.go
+++ b/library/trakt.go
@@ -648,7 +648,7 @@ func updateShowWatched(xbmcHost *xbmc.XBMCHost, s *trakt.WatchedShow, watched bo
 
 // RefreshTraktCollected ...
 func RefreshTraktCollected(xbmcHost *xbmc.XBMCHost, itemType int, isRefreshNeeded bool) error {
-	if config.Get().TraktToken == "" || !config.Get().TraktSyncCollections {
+	if config.Get().TraktToken == "" {
 		return nil
 	}
 
@@ -669,7 +669,7 @@ func RefreshTraktCollected(xbmcHost *xbmc.XBMCHost, itemType int, isRefreshNeede
 
 // RefreshTraktWatchlisted ...
 func RefreshTraktWatchlisted(xbmcHost *xbmc.XBMCHost, itemType int, isRefreshNeeded bool) error {
-	if config.Get().TraktToken == "" || !config.Get().TraktSyncWatchlist {
+	if config.Get().TraktToken == "" {
 		return nil
 	}
 
@@ -798,7 +798,7 @@ func RefreshTraktHidden(xbmcHost *xbmc.XBMCHost, itemType int, isRefreshNeeded b
 
 // RefreshTraktLists ...
 func RefreshTraktLists(xbmcHost *xbmc.XBMCHost, isRefreshNeeded bool) error {
-	if config.Get().TraktToken == "" || !config.Get().TraktSyncUserlists {
+	if config.Get().TraktToken == "" {
 		return nil
 	}
 


### PR DESCRIPTION
right now if we disable settings like "Sync items from ... into Kodi library" then we do not update data about collection/watchlist/userlists anymore, thus even in internal elementum menus we see old data for those lists.

fixes https://github.com/elgatito/plugin.video.elementum/issues/680