### PR TITLE
fix crash in tmdb/tmdb.go CountRealSeasons()

### DIFF
--- a/tmdb/tmdb.go
+++ b/tmdb/tmdb.go
@@ -729,6 +729,9 @@ func (show *Show) CountRealSeasons() int {
 
 	ret := 0
 	for _, s := range show.Seasons {
+		if s == nil {
+			continue
+		}
 		if !c.ShowUnairedSeasons {
 			if _, isExpired := util.AirDateWithExpireCheck(s.AirDate, time.DateOnly, c.ShowEpisodesOnReleaseDay); isExpired {
 				continue

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -1177,6 +1177,9 @@ func (show *Show) CountRealSeasons() int {
 
 	ret := 0
 	for _, s := range seasons {
+		if s == nil {
+			continue
+		}
 		if !c.ShowUnairedSeasons {
 			if _, isExpired := util.AirDateWithExpireCheck(s.FirstAired, time.RFC3339, c.ShowEpisodesOnReleaseDay); isExpired {
 				continue


### PR DESCRIPTION
fix for crash:
```
[plugin.video.elementum] Requesting http://127.0.0.1:65220/shows/trakt/recommendations?doresume=false from ['plugin://plugin.video.elementum/shows/trakt/recommendations', '17', '', 'resume:false']
[plugin.video.elementum] 
[plugin.video.elementum] [31m2024/01/12 19:08:42 [Recovery] 2024/01/12 - 19:08:42 panic recovered: invalid memory address or nil pointer dereference
[plugin.video.elementum] /usr/arm-linux-androideabi/go/src/runtime/panic.go:261 (0x9261c27)
[plugin.video.elementum] /usr/arm-linux-androideabi/go/src/runtime/signal_unix.go:861 (0x9261bdc)
[plugin.video.elementum] /go/src/github.com/elgatito/elementum/tmdb/tmdb.go:733 (0x9a101d8)
[plugin.video.elementum] /go/src/github.com/elgatito/elementum/tmdb/show.go:576 (0x9a0aed3)
[plugin.video.elementum] /go/src/github.com/elgatito/elementum/trakt/shows.go:975 (0x9b03f07)
[plugin.video.elementum] /go/src/github.com/elgatito/elementum/api/trakt.go:804 (0x9c42837)
[plugin.video.elementum] /go/src/github.com/elgatito/elementum/api/trakt.go:896 (0x9c44c0b)
[plugin.video.elementum] /go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x98292ab)
[plugin.video.elementum] /go/src/github.com/elgatito/elementum/api/routes.go:40 (0x9c5300b)
[plugin.video.elementum] /go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x98292ab)
[plugin.video.elementum] /go/src/github.com/elgatito/elementum/api/routes.go:32 (0x9c52f73)
[plugin.video.elementum] /go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9835ce7)
[plugin.video.elementum] /go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/logger.go:240 (0x9835cb8)
[plugin.video.elementum] /go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9836bcb)
[plugin.video.elementum] /go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/recovery.go:102 (0x9836bac)
[plugin.video.elementum] /go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9834a8b)
[plugin.video.elementum] /go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:620 (0x9834774)
[plugin.video.elementum] /go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:576 (0x983431f)
[plugin.video.elementum] /usr/arm-linux-androideabi/go/src/net/http/server.go:2514 (0x957e867)
[plugin.video.elementum] /usr/arm-linux-androideabi/go/src/net/http/server.go:2938 (0x957fc1f)
[plugin.video.elementum] /usr/arm-linux-androideabi/go/src/net/http/server.go:2009 (0x957b5bb)
[plugin.video.elementum] /usr/arm-linux-androideabi/go/src/runtime/asm_arm.s:859 (0x928580b)
[plugin.video.elementum] [0m
```