### PR TITLE
Consolidate Art code for TMDB and Trakt

### DIFF
--- a/api/infolabels.go
+++ b/api/infolabels.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"errors"
-	"math/rand"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -159,7 +158,7 @@ func InfoLabelsSearch(s *bittorrent.Service) gin.HandlerFunc {
 	}
 }
 
-// GetEpisodeLabels returns listitem for an episode
+// GetEpisodeLabels returns ListItem for an episode
 func GetEpisodeLabels(showID, seasonNumber, episodeNumber int) (item *xbmc.ListItem, err error) {
 	show := tmdb.GetShow(showID, config.Get().Language)
 	if show == nil {
@@ -183,23 +182,11 @@ func GetEpisodeLabels(showID, seasonNumber, episodeNumber int) (item *xbmc.ListI
 			item.Info.DBID = le.UIDs.Kodi
 		}
 	}
-	if item.Art != nil {
-		if item.Art.FanArt == "" {
-			fanarts := make([]string, 0)
-			for _, backdrop := range show.Images.Backdrops {
-				fanarts = append(fanarts, tmdb.ImageURL(backdrop.FilePath, "w1280"))
-			}
-			if len(fanarts) > 0 {
-				item.Art.FanArt = fanarts[rand.Intn(len(fanarts))]
-			}
-		}
-		item.Art.Poster = tmdb.ImageURL(season.Poster, "w1280")
-	}
 
 	return
 }
 
-// GetMovieLabels returns listitem for a movie
+// GetMovieLabels returns ListItem for a movie
 func GetMovieLabels(tmdbID string) (item *xbmc.ListItem, err error) {
 	movie := tmdb.GetMovieByID(tmdbID, config.Get().Language)
 	if movie == nil {
@@ -215,7 +202,7 @@ func GetMovieLabels(tmdbID string) (item *xbmc.ListItem, err error) {
 	return
 }
 
-// GetSearchLabels returns listitem for a search query
+// GetSearchLabels returns ListItem for a search query
 func GetSearchLabels(s *bittorrent.Service, tmdbID string, idx string) (item *xbmc.ListItem, err error) {
 	torrent := s.HasTorrentByFakeID(tmdbID)
 	if torrent == nil || torrent.DBItem == nil {

--- a/api/trakt.go
+++ b/api/trakt.go
@@ -1401,6 +1401,9 @@ func renderCalendarShows(ctx *gin.Context, shows []*trakt.CalendarShow, total in
 			} else {
 				item = epi.ToListItem(showListing.Show, show)
 			}
+			if item == nil {
+				return
+			}
 
 			item.Info.Aired = airDate
 			item.Info.DateAdded = airDate
@@ -1560,6 +1563,9 @@ func renderProgressShows(ctx *gin.Context, shows []*trakt.ProgressShow, total in
 				item = episode.ToListItem(show, season)
 			} else {
 				item = epi.ToListItem(showListing.Show, show)
+			}
+			if item == nil {
+				return
 			}
 
 			item.Info.Aired = airDate

--- a/fanart/fanart.go
+++ b/fanart/fanart.go
@@ -366,6 +366,7 @@ func (fa *Show) ToListItemArt(old *xbmc.ListItemArt) *xbmc.ListItemArt {
 		KeyArt:    GetMultipleShowImage("", old.KeyArt, fa.ShowBackground),
 	}
 	return &xbmc.ListItemArt{
+		TvShowPoster:      GetBestShowImage("", false, old.Poster, fa.TVPoster),
 		Poster:            GetBestShowImage("", false, old.Poster, fa.TVPoster),
 		Thumbnail:         old.Thumbnail,
 		Banner:            GetBestShowImage("", false, old.Banner, fa.TVBanner),
@@ -386,16 +387,27 @@ func (fa *Show) ToSeasonListItemArt(season int, old *xbmc.ListItemArt) *xbmc.Lis
 		old = &xbmc.ListItemArt{}
 	}
 
+	availableArtworks := &xbmc.Artworks{
+		Poster:    GetMultipleShowImage(s, old.Poster, fa.SeasonPoster, fa.TVPoster),
+		Banner:    GetMultipleShowImage(s, old.Banner, fa.SeasonBanner, fa.TVBanner),
+		FanArt:    GetMultipleShowImage(s, old.FanArt, fa.ShowBackground),
+		ClearArt:  GetMultipleShowImage(s, old.ClearArt, fa.HDClearArt, fa.ClearArt),
+		ClearLogo: GetMultipleShowImage(s, old.ClearLogo, fa.HdtvLogo, fa.ClearLogo),
+		Landscape: GetMultipleShowImage(s, old.Landscape, fa.SeasonThumb, fa.TVThumb),
+		KeyArt:    GetMultipleShowImage(s, old.KeyArt, fa.ShowBackground),
+	}
 	return &xbmc.ListItemArt{
-		TvShowPoster: GetBestShowImage("", true, old.Poster, fa.SeasonPoster, fa.TVPoster),
-		Poster:       GetBestShowImage(s, true, old.Poster, fa.SeasonPoster, fa.TVPoster),
-		Thumbnail:    old.Thumbnail,
-		Banner:       GetBestShowImage(s, true, old.Banner, fa.SeasonBanner, fa.TVBanner),
-		FanArt:       GetBestShowImage(s, false, old.FanArt, fa.ShowBackground),
-		FanArts:      GetMultipleShowImage(s, old.FanArt, fa.ShowBackground),
-		ClearArt:     GetBestShowImage(s, false, old.ClearArt, fa.HDClearArt, fa.ClearArt),
-		ClearLogo:    GetBestShowImage(s, false, old.ClearLogo, fa.HdtvLogo, fa.ClearLogo),
-		Landscape:    GetBestShowImage(s, true, old.Landscape, fa.SeasonThumb, fa.TVThumb),
+		TvShowPoster:      GetBestShowImage("", true, old.Poster, fa.SeasonPoster, fa.TVPoster),
+		Poster:            GetBestShowImage(s, true, old.Poster, fa.SeasonPoster, fa.TVPoster),
+		Thumbnail:         old.Thumbnail,
+		Banner:            GetBestShowImage(s, true, old.Banner, fa.SeasonBanner, fa.TVBanner),
+		FanArt:            GetBestShowImage(s, false, old.FanArt, fa.ShowBackground),
+		FanArts:           GetMultipleShowImage(s, old.FanArt, fa.ShowBackground),
+		ClearArt:          GetBestShowImage(s, false, old.ClearArt, fa.HDClearArt, fa.ClearArt),
+		ClearLogo:         GetBestShowImage(s, false, old.ClearLogo, fa.HdtvLogo, fa.ClearLogo),
+		Landscape:         GetBestShowImage(s, true, old.Landscape, fa.SeasonThumb, fa.TVThumb),
+		KeyArt:            GetBestShowImage(s, false, old.KeyArt, fa.ShowBackground),
+		AvailableArtworks: availableArtworks,
 	}
 }
 
@@ -406,16 +418,27 @@ func (fa *Show) ToEpisodeListItemArt(season int, old *xbmc.ListItemArt) *xbmc.Li
 		old = &xbmc.ListItemArt{}
 	}
 
+	availableArtworks := &xbmc.Artworks{
+		Poster:    GetMultipleShowImage(s, old.Poster, fa.SeasonPoster, fa.TVPoster),
+		Banner:    GetMultipleShowImage(s, old.Banner, fa.SeasonBanner, fa.TVBanner),
+		FanArt:    GetMultipleShowImage(s, old.FanArt, fa.ShowBackground),
+		ClearArt:  GetMultipleShowImage(s, old.ClearArt, fa.HDClearArt, fa.ClearArt),
+		ClearLogo: GetMultipleShowImage(s, old.ClearLogo, fa.HdtvLogo, fa.ClearLogo),
+		Landscape: GetMultipleShowImage(s, old.Landscape, fa.SeasonThumb, fa.TVThumb),
+		KeyArt:    GetMultipleShowImage(s, old.KeyArt, fa.ShowBackground),
+	}
 	return &xbmc.ListItemArt{
-		TvShowPoster: GetBestShowImage("", true, old.Poster, fa.SeasonPoster, fa.TVPoster),
-		Poster:       GetBestShowImage(s, true, old.Poster, fa.SeasonPoster, fa.TVPoster),
-		Thumbnail:    old.Thumbnail,
-		Banner:       GetBestShowImage(s, true, old.Banner, fa.SeasonBanner, fa.TVBanner),
-		FanArt:       GetBestShowImage(s, false, old.FanArt, fa.ShowBackground),
-		FanArts:      GetMultipleShowImage(s, old.FanArt, fa.ShowBackground),
-		ClearArt:     GetBestShowImage(s, false, old.ClearArt, fa.HDClearArt, fa.ClearArt),
-		ClearLogo:    GetBestShowImage(s, false, old.ClearLogo, fa.HdtvLogo, fa.ClearLogo),
-		Landscape:    GetBestShowImage(s, true, old.Landscape, fa.SeasonThumb, fa.TVThumb),
+		TvShowPoster:      GetBestShowImage("", true, old.Poster, fa.SeasonPoster, fa.TVPoster),
+		Poster:            GetBestShowImage(s, true, old.Poster, fa.SeasonPoster, fa.TVPoster),
+		Thumbnail:         old.Thumbnail,
+		Banner:            GetBestShowImage(s, true, old.Banner, fa.SeasonBanner, fa.TVBanner),
+		FanArt:            GetBestShowImage(s, false, old.FanArt, fa.ShowBackground),
+		FanArts:           GetMultipleShowImage(s, old.FanArt, fa.ShowBackground),
+		ClearArt:          GetBestShowImage(s, false, old.ClearArt, fa.HDClearArt, fa.ClearArt),
+		ClearLogo:         GetBestShowImage(s, false, old.ClearLogo, fa.HdtvLogo, fa.ClearLogo),
+		Landscape:         GetBestShowImage(s, true, old.Landscape, fa.SeasonThumb, fa.TVThumb),
+		KeyArt:            GetBestShowImage(s, false, old.KeyArt, fa.ShowBackground),
+		AvailableArtworks: availableArtworks,
 	}
 }
 

--- a/tmdb/episode.go
+++ b/tmdb/episode.go
@@ -95,7 +95,7 @@ func (episode *Episode) SetArt(show *Show, season *Season, item *xbmc.ListItem) 
 	}
 
 	if config.Get().UseFanartTv {
-		if show.FanArt == nil {
+		if show.FanArt == nil && show.ExternalIDs != nil {
 			show.FanArt = fanart.GetShow(util.StrInterfaceToInt(show.ExternalIDs.TVDBID))
 		}
 		if show.FanArt != nil {
@@ -137,8 +137,6 @@ func (episode *Episode) ToListItem(show *Show, season *Season) *xbmc.ListItem {
 			Votes:         strconv.Itoa(episode.VoteCount),
 			Aired:         episode.AirDate,
 			Duration:      runtime,
-			Code:          show.ExternalIDs.IMDBId,
-			IMDBNumber:    show.ExternalIDs.IMDBId,
 			PlayCount:     playcount.GetWatchedEpisodeByTMDB(show.ID, episode.SeasonNumber, episode.EpisodeNumber).Int(),
 			MPAA:          show.mpaa(),
 			DBTYPE:        "episode",
@@ -153,6 +151,10 @@ func (episode *Episode) ToListItem(show *Show, season *Season) *xbmc.ListItem {
 		Properties: &xbmc.ListItemProperties{
 			ShowTMDBId: strconv.Itoa(show.ID),
 		},
+	}
+	if show.ExternalIDs != nil {
+		item.Info.Code = show.ExternalIDs.IMDBId
+		item.Info.IMDBNumber = show.ExternalIDs.IMDBId
 	}
 
 	if ls, err := uid.GetShowByTMDB(show.ID); ls != nil && err == nil {

--- a/tmdb/episode.go
+++ b/tmdb/episode.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/elgatito/elementum/cache"
 	"github.com/elgatito/elementum/config"
+	"github.com/elgatito/elementum/fanart"
 	"github.com/elgatito/elementum/library/playcount"
 	"github.com/elgatito/elementum/library/uid"
 	"github.com/elgatito/elementum/util"
@@ -55,11 +56,6 @@ func (episodes EpisodeList) ToListItems(show *Show, season *Season) []*xbmc.List
 		return items
 	}
 
-	fanarts := make([]string, 0)
-	for _, backdrop := range show.Images.Backdrops {
-		fanarts = append(fanarts, ImageURL(backdrop.FilePath, "w1280"))
-	}
-
 	for _, episode := range episodes {
 		if episode == nil {
 			continue
@@ -76,17 +72,36 @@ func (episodes EpisodeList) ToListItems(show *Show, season *Season) []*xbmc.List
 
 		item := episode.ToListItem(show, season)
 
-		if item.Art.FanArt == "" && len(fanarts) > 0 {
-			item.Art.FanArt = fanarts[rand.Intn(len(fanarts))]
-		}
-
-		if item.Art.FanArt == "" && season.Poster != "" {
-			item.Art.Poster = ImageURL(season.Poster, "w1280")
-		}
-
 		items = append(items, item)
 	}
 	return items
+}
+
+// SetArt sets artworks for episode
+func (episode *Episode) SetArt(show *Show, season *Season, item *xbmc.ListItem) {
+	if item.Art == nil {
+		item.Art = &xbmc.ListItemArt{}
+	}
+
+	if episode.StillPath != "" {
+		item.Art.FanArt = ImageURL(episode.StillPath, "w1280")
+		item.Art.Banner = ImageURL(episode.StillPath, "w1280")
+		item.Art.Poster = ImageURL(episode.StillPath, "w1280")
+		item.Art.Thumbnail = ImageURL(episode.StillPath, "w1280")
+		item.Art.TvShowPoster = ImageURL(episode.StillPath, "w1280")
+	} else {
+		// Use the season's artwork as a fallback
+		season.SetArt(show, item)
+	}
+
+	if config.Get().UseFanartTv {
+		if show.FanArt == nil {
+			show.FanArt = fanart.GetShow(util.StrInterfaceToInt(show.ExternalIDs.TVDBID))
+		}
+		if show.FanArt != nil {
+			item.Art = show.FanArt.ToEpisodeListItemArt(season.Season, item.Art)
+		}
+	}
 }
 
 // ToListItem ...
@@ -132,7 +147,6 @@ func (episode *Episode) ToListItem(show *Show, season *Season) *xbmc.ListItem {
 			Studio:        show.GetStudios(),
 			Country:       show.GetCountries(),
 		},
-		Art: &xbmc.ListItemArt{},
 		UniqueIDs: &xbmc.UniqueIDs{
 			TMDB: strconv.Itoa(episode.ID),
 		},
@@ -147,39 +161,7 @@ func (episode *Episode) ToListItem(show *Show, season *Season) *xbmc.ListItem {
 		}
 	}
 
-	if show.PosterPath != "" {
-		item.Art.TvShowPoster = ImageURL(show.PosterPath, "w1280")
-		item.Art.FanArt = ImageURL(show.BackdropPath, "w1280")
-		item.Art.Thumbnail = ImageURL(show.PosterPath, "w1280")
-		item.Thumbnail = ImageURL(show.PosterPath, "w1280")
-	} else if show.Images != nil {
-		fanarts := []string{}
-		for _, backdrop := range show.Images.Backdrops {
-			fanarts = append(fanarts, ImageURL(backdrop.FilePath, "w1280"))
-		}
-		if len(fanarts) > 0 {
-			item.Art.FanArt = fanarts[rand.Intn(len(fanarts))]
-		}
-
-		fanarts = []string{}
-		for _, poster := range show.Images.Posters {
-			fanarts = append(fanarts, ImageURL(poster.FilePath, "w1280"))
-		}
-		if len(fanarts) > 0 {
-			item.Art.TvShowPoster = fanarts[rand.Intn(len(fanarts))]
-		}
-	}
-
-	if config.Get().UseFanartTv && show.FanArt != nil {
-		item.Art = show.FanArt.ToEpisodeListItemArt(season.Season, item.Art)
-	}
-
-	if episode.StillPath != "" {
-		item.Art.FanArt = ImageURL(episode.StillPath, "w1280")
-		item.Art.Thumbnail = ImageURL(episode.StillPath, "w1280")
-		item.Art.Poster = ImageURL(episode.StillPath, "w1280")
-		item.Thumbnail = ImageURL(episode.StillPath, "w1280")
-	}
+	episode.SetArt(show, season, item)
 
 	if season != nil && episode.Credits == nil && season.Credits != nil {
 		episode.Credits = season.Credits

--- a/tmdb/season.go
+++ b/tmdb/season.go
@@ -198,7 +198,7 @@ func (season *Season) SetArt(show *Show, item *xbmc.ListItem) {
 	}
 
 	if config.Get().UseFanartTv {
-		if show.FanArt == nil {
+		if show.FanArt == nil && show.ExternalIDs != nil {
 			show.FanArt = fanart.GetShow(util.StrInterfaceToInt(show.ExternalIDs.TVDBID))
 		}
 		if show.FanArt != nil {
@@ -211,6 +211,8 @@ func (season *Season) SetArt(show *Show, item *xbmc.ListItem) {
 
 // ToListItem ...
 func (season *Season) ToListItem(show *Show) *xbmc.ListItem {
+	defer perf.ScopeTimer()()
+
 	name := fmt.Sprintf("Season %d", season.Season)
 	if season.name(show) != "" {
 		name = season.name(show)
@@ -236,8 +238,6 @@ func (season *Season) ToListItem(show *Show) *xbmc.ListItem {
 			MPAA:          show.mpaa(),
 			DBTYPE:        "season",
 			Mediatype:     "season",
-			Code:          show.ExternalIDs.IMDBId,
-			IMDBNumber:    show.ExternalIDs.IMDBId,
 			PlayCount:     playcount.GetWatchedSeasonByTMDB(show.ID, season.Season).Int(),
 			Genre:         show.GetGenres(),
 			Studio:        show.GetStudios(),
@@ -249,6 +249,10 @@ func (season *Season) ToListItem(show *Show) *xbmc.ListItem {
 		UniqueIDs: &xbmc.UniqueIDs{
 			TMDB: strconv.Itoa(season.ID),
 		},
+	}
+	if show.ExternalIDs != nil {
+		item.Info.Code = show.ExternalIDs.IMDBId
+		item.Info.IMDBNumber = show.ExternalIDs.IMDBId
 	}
 
 	if ls, err := uid.GetShowByTMDB(show.ID); ls != nil && err == nil {

--- a/tmdb/season.go
+++ b/tmdb/season.go
@@ -138,77 +138,63 @@ func (seasons SeasonList) Less(i, j int) bool { return seasons[i].Season < seaso
 // SetArt sets artworks for season
 func (season *Season) SetArt(show *Show, item *xbmc.ListItem) {
 	if item.Art == nil {
-		item.Art = &xbmc.ListItemArt{
-			FanArt:       ImageURL(season.Backdrop, "w1280"),
-			Banner:       ImageURL(season.Backdrop, "w1280"),
-			Poster:       ImageURL(season.Poster, "w1280"),
-			Thumbnail:    ImageURL(season.Poster, "w1280"),
-			TvShowPoster: ImageURL(show.PosterPath, "w1280"),
-		}
+		item.Art = &xbmc.ListItemArt{}
 	}
 
-	// Fallback to show art if season art is empty
-	if item.Art.Poster == "" {
-		item.Art.Poster = ImageURL(show.PosterPath, "w1280")
-		item.Art.Thumbnail = ImageURL(show.PosterPath, "w1280")
+	// Use the show's artwork as a fallback
+	show.SetArt(item)
+
+	if season.Poster != "" {
+		item.Art.Poster = ImageURL(season.Poster, "w1280")
+		item.Art.Thumbnail = ImageURL(season.Poster, "w1280")
 	}
-	if item.Art.Banner == "" {
-		item.Art.Banner = ImageURL(show.BackdropPath, "w1280")
-		item.Art.FanArt = ImageURL(show.BackdropPath, "w1280")
+	if season.Backdrop != "" {
+		item.Art.FanArt = ImageURL(season.Backdrop, "w1280")
+		item.Art.Banner = ImageURL(season.Backdrop, "w1280")
 	}
 
 	if item.Art.AvailableArtworks == nil {
 		item.Art.AvailableArtworks = &xbmc.Artworks{}
 	}
 
-	var thisBackdrops []*Image
-	if show.Images != nil && show.Images.Backdrops != nil && len(show.Images.Backdrops) != 0 {
-		thisBackdrops = show.Images.Backdrops
-	}
-	if season.Images != nil && season.Images.Backdrops != nil && len(season.Images.Backdrops) != 0 {
-		thisBackdrops = season.Images.Backdrops
-	}
-	fanarts := make([]string, 0)
-	foundLanguageSpecificImage := false
-	for _, backdrop := range thisBackdrops {
-		// for AvailableArtworks
-		fanarts = append(fanarts, ImageURL(backdrop.FilePath, "w1280"))
+	if season.Images != nil && season.Images.Backdrops != nil {
+		fanarts := make([]string, 0)
+		foundLanguageSpecificImage := false
+		for _, backdrop := range season.Images.Backdrops {
+			// for AvailableArtworks
+			fanarts = append(fanarts, ImageURL(backdrop.FilePath, "w1280"))
 
-		// try to use language specific art
-		if !foundLanguageSpecificImage && backdrop.Iso639_1 == config.Get().Language {
-			item.Art.FanArt = ImageURL(backdrop.FilePath, "w1280")
-			item.Art.Banner = ImageURL(backdrop.FilePath, "w1280")
-			foundLanguageSpecificImage = true // we take first image, it has top rating
+			// try to use language specific art
+			if !foundLanguageSpecificImage && backdrop.Iso639_1 == config.Get().Language {
+				item.Art.FanArt = ImageURL(backdrop.FilePath, "w1280")
+				item.Art.Banner = ImageURL(backdrop.FilePath, "w1280")
+				foundLanguageSpecificImage = true // we take first image, it has top rating
+			}
+		}
+		if len(fanarts) > 0 {
+			item.Art.FanArts = fanarts
+			item.Art.AvailableArtworks.FanArt = fanarts
+			item.Art.AvailableArtworks.Banner = fanarts
 		}
 	}
-	if len(fanarts) > 0 {
-		item.Art.FanArts = fanarts
-		item.Art.AvailableArtworks.FanArt = fanarts
-		item.Art.AvailableArtworks.Banner = fanarts
-	}
 
-	var thisPosters []*Image
-	if show.Images != nil && show.Images.Posters != nil && len(show.Images.Posters) != 0 {
-		thisPosters = show.Images.Posters
-	}
-	if season.Images != nil && season.Images.Posters != nil && len(season.Images.Posters) != 0 {
-		thisPosters = season.Images.Posters
-	}
-	posters := make([]string, 0)
-	foundLanguageSpecificImage = false
-	for _, poster := range thisPosters {
-		// for AvailableArtworks
-		posters = append(posters, ImageURL(poster.FilePath, "w1280"))
+	if season.Images != nil && season.Images.Posters != nil {
+		posters := make([]string, 0)
+		foundLanguageSpecificImage := false
+		for _, poster := range season.Images.Posters {
+			// for AvailableArtworks
+			posters = append(posters, ImageURL(poster.FilePath, "w1280"))
 
-		// try to use language specific art
-		if !foundLanguageSpecificImage && poster.Iso639_1 == config.Get().Language {
-			item.Art.Poster = ImageURL(poster.FilePath, "w1280")
-			item.Art.Thumbnail = ImageURL(poster.FilePath, "w1280")
-			foundLanguageSpecificImage = true // we take first image, it has top rating
+			// try to use language specific art
+			if !foundLanguageSpecificImage && poster.Iso639_1 == config.Get().Language {
+				item.Art.Poster = ImageURL(poster.FilePath, "w1280")
+				item.Art.Thumbnail = ImageURL(poster.FilePath, "w1280")
+				foundLanguageSpecificImage = true // we take first image, it has top rating
+			}
 		}
-	}
-	if len(posters) > 0 {
-		item.Art.AvailableArtworks.Poster = posters
+		if len(posters) > 0 {
+			item.Art.AvailableArtworks.Poster = posters
+		}
 	}
 
 	if config.Get().UseFanartTv {

--- a/tmdb/show.go
+++ b/tmdb/show.go
@@ -506,14 +506,14 @@ func (show *Show) ShowInfoWithTVDBShow(episode *Episode, tvdbShow *tvdb.Show) (a
 // SetArt sets artworks for show
 func (show *Show) SetArt(item *xbmc.ListItem) {
 	if item.Art == nil {
-		item.Art = &xbmc.ListItemArt{
-			FanArt:       ImageURL(show.BackdropPath, "w1280"),
-			Banner:       ImageURL(show.BackdropPath, "w1280"),
-			Poster:       ImageURL(show.PosterPath, "w1280"),
-			Thumbnail:    ImageURL(show.PosterPath, "w1280"),
-			TvShowPoster: ImageURL(show.PosterPath, "w1280"),
-		}
+		item.Art = &xbmc.ListItemArt{}
 	}
+
+	item.Art.FanArt = ImageURL(show.BackdropPath, "w1280")
+	item.Art.Banner = ImageURL(show.BackdropPath, "w1280")
+	item.Art.Poster = ImageURL(show.PosterPath, "w1280")
+	item.Art.Thumbnail = ImageURL(show.PosterPath, "w1280")
+	item.Art.TvShowPoster = ImageURL(show.PosterPath, "w1280")
 
 	if item.Art.AvailableArtworks == nil {
 		item.Art.AvailableArtworks = &xbmc.Artworks{}

--- a/tmdb/show.go
+++ b/tmdb/show.go
@@ -560,7 +560,7 @@ func (show *Show) SetArt(item *xbmc.ListItem) {
 	}
 
 	if config.Get().UseFanartTv {
-		if show.FanArt == nil {
+		if show.FanArt == nil && show.ExternalIDs != nil {
 			show.FanArt = fanart.GetShow(util.StrInterfaceToInt(show.ExternalIDs.TVDBID))
 		}
 		if show.FanArt != nil {
@@ -596,8 +596,6 @@ func (show *Show) ToListItem() *xbmc.ListItem {
 			OriginalTitle: show.OriginalName,
 			Plot:          show.overview(),
 			PlotOutline:   show.overview(),
-			Code:          show.ExternalIDs.IMDBId,
-			IMDBNumber:    show.ExternalIDs.IMDBId,
 			Date:          show.FirstAirDate,
 			Votes:         strconv.Itoa(show.VoteCount),
 			Rating:        show.VoteAverage,
@@ -618,6 +616,10 @@ func (show *Show) ToListItem() *xbmc.ListItem {
 		UniqueIDs: &xbmc.UniqueIDs{
 			TMDB: strconv.Itoa(show.ID),
 		},
+	}
+	if show.ExternalIDs != nil {
+		item.Info.Code = show.ExternalIDs.IMDBId
+		item.Info.IMDBNumber = show.ExternalIDs.IMDBId
 	}
 
 	if ls, err := uid.GetShowByTMDB(show.ID); ls != nil && err == nil {

--- a/trakt/movies.go
+++ b/trakt/movies.go
@@ -564,7 +564,7 @@ func PausedMovies(isUpdateNeeded bool) ([]*PausedMovie, error) {
 func (movie *Movie) ToListItem(tmdbMovie *tmdb.Movie) (item *xbmc.ListItem) {
 	defer perf.ScopeTimer()()
 
-	if movie.IDs.TMDB != 0 {
+	if tmdbMovie == nil && movie.IDs.TMDB != 0 {
 		if tmdbMovie = tmdb.GetMovie(movie.IDs.TMDB, config.Get().Language); tmdbMovie != nil {
 			if !config.Get().ForceUseTrakt {
 				item = tmdbMovie.ToListItem()

--- a/trakt/movies.go
+++ b/trakt/movies.go
@@ -20,56 +20,6 @@ import (
 	"github.com/jmcvetta/napping"
 )
 
-// Fill fanart from TMDB
-func setFanart(movie *Movie, tmdbMovie *tmdb.Movie) *Movie {
-	if movie.Images == nil {
-		movie.Images = &Images{}
-	}
-	if movie.Images.Poster == nil {
-		movie.Images.Poster = &Sizes{}
-	}
-	if movie.Images.Thumbnail == nil {
-		movie.Images.Thumbnail = &Sizes{}
-	}
-	if movie.Images.FanArt == nil {
-		movie.Images.FanArt = &Sizes{}
-	}
-	if movie.Images.Banner == nil {
-		movie.Images.Banner = &Sizes{}
-	}
-	if movie.Images.ClearArt == nil {
-		movie.Images.ClearArt = &Sizes{}
-	}
-
-	if movie.IDs == nil || movie.IDs.TMDB == 0 || tmdbMovie == nil || tmdbMovie.Images == nil {
-		return movie
-	}
-
-	if len(tmdbMovie.Images.Posters) > 0 {
-		posterImage := tmdb.ImageURL(tmdbMovie.Images.Posters[0].FilePath, "w1280")
-		for _, image := range tmdbMovie.Images.Posters {
-			if image.Iso639_1 == config.Get().Language {
-				posterImage = tmdb.ImageURL(image.FilePath, "w1280")
-				break
-			}
-		}
-		movie.Images.Poster.Full = posterImage
-		movie.Images.Thumbnail.Full = posterImage
-	}
-	if len(tmdbMovie.Images.Backdrops) > 0 {
-		backdropImage := tmdb.ImageURL(tmdbMovie.Images.Backdrops[0].FilePath, "w1280")
-		for _, image := range tmdbMovie.Images.Backdrops {
-			if image.Iso639_1 == config.Get().Language {
-				backdropImage = tmdb.ImageURL(image.FilePath, "w1280")
-				break
-			}
-		}
-		movie.Images.FanArt.Full = backdropImage
-		movie.Images.Banner.Full = backdropImage
-	}
-	return movie
-}
-
 // GetMovie ...
 func GetMovie(ID string) (movie *Movie) {
 	defer perf.ScopeTimer()()
@@ -79,7 +29,7 @@ func GetMovie(ID string) (movie *Movie) {
 		URL:    fmt.Sprintf("movies/%s", ID),
 		Header: GetAvailableHeader(),
 		Params: napping.Params{
-			"extended": "full,images",
+			"extended": "full",
 		}.AsUrlValues(),
 		Result:      &movie,
 		Description: "trakt movie",
@@ -142,7 +92,7 @@ func SearchMovies(query string, page string) (movies []*Movies, err error) {
 			"page":     page,
 			"limit":    strconv.Itoa(config.Get().ResultsPerPage),
 			"query":    query,
-			"extended": "full,images",
+			"extended": "full",
 		}.AsUrlValues(),
 		Result:      &movies,
 		Description: "movie search",
@@ -190,7 +140,7 @@ func TopMovies(topCategory string, page string) (movies []*Movies, total int, er
 		Params: napping.Params{
 			"page":     page,
 			"limit":    strconv.Itoa(limit),
-			"extended": "full,images",
+			"extended": "full",
 		}.AsUrlValues(),
 		Result:      &movies,
 		Description: "list movies",
@@ -257,7 +207,7 @@ func WatchlistMovies(isUpdateNeeded bool) (movies []*Movies, err error) {
 		URL:    "sync/watchlist/movies",
 		Header: GetAvailableHeader(),
 		Params: napping.Params{
-			"extended": "full,images",
+			"extended": "full",
 		}.AsUrlValues(),
 		Result:      &watchlist,
 		Description: "watchlist movies",
@@ -315,7 +265,7 @@ func CollectionMovies(isUpdateNeeded bool) (movies []*Movies, err error) {
 		URL:    "sync/collection/movies",
 		Header: GetAvailableHeader(),
 		Params: napping.Params{
-			"extended": "full,images",
+			"extended": "full",
 		}.AsUrlValues(),
 		Result:      &collection,
 		Description: "collection movies",
@@ -531,7 +481,7 @@ func CalendarMovies(endPoint string, page string) (movies []*CalendarMovie, tota
 		Params: napping.Params{
 			"page":     page,
 			"limit":    strconv.Itoa(limit),
-			"extended": "full,images",
+			"extended": "full",
 		}.AsUrlValues(),
 		Result:      &movies,
 		Description: "calendar movies",
@@ -615,15 +565,13 @@ func (movie *Movie) ToListItem(tmdbMovie *tmdb.Movie) (item *xbmc.ListItem) {
 	defer perf.ScopeTimer()()
 
 	if movie.IDs.TMDB != 0 {
-		tmdbID := strconv.Itoa(movie.IDs.TMDB)
-		if tmdbMovie = tmdb.GetMovieByID(tmdbID, config.Get().Language); tmdbMovie != nil {
+		if tmdbMovie = tmdb.GetMovie(movie.IDs.TMDB, config.Get().Language); tmdbMovie != nil {
 			if !config.Get().ForceUseTrakt {
 				item = tmdbMovie.ToListItem()
 			}
 		}
 	}
 	if item == nil {
-		movie = setFanart(movie, tmdbMovie)
 		item = &xbmc.ListItem{
 			Label: movie.Title,
 			Info: &xbmc.ListItemInfo{
@@ -646,17 +594,12 @@ func (movie *Movie) ToListItem(tmdbMovie *tmdb.Movie) (item *xbmc.ListItem) {
 				DBTYPE:        "movie",
 				Mediatype:     "movie",
 			},
-			Art: &xbmc.ListItemArt{
-				Poster:    movie.Images.Poster.Full,
-				FanArt:    movie.Images.FanArt.Full,
-				Banner:    movie.Images.Banner.Full,
-				Thumbnail: movie.Images.Thumbnail.Full,
-				ClearArt:  movie.Images.ClearArt.Full,
-			},
-			Thumbnail: movie.Images.Poster.Full,
 			UniqueIDs: &xbmc.UniqueIDs{
 				TMDB: strconv.Itoa(movie.IDs.TMDB),
 			},
+		}
+		if tmdbMovie != nil {
+			tmdbMovie.SetArt(item)
 		}
 	}
 

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -789,8 +789,10 @@ func (show *Show) ToListItem() (item *xbmc.ListItem) {
 
 	var tmdbShow *tmdb.Show
 	if show.IDs.TMDB != 0 {
-		if tmdbShow = tmdb.GetShow(show.IDs.TMDB, config.Get().Language); tmdbShow != nil && !config.Get().ForceUseTrakt {
-			item = tmdbShow.ToListItem()
+		if tmdbShow = tmdb.GetShow(show.IDs.TMDB, config.Get().Language); tmdbShow != nil {
+			if !config.Get().ForceUseTrakt {
+				item = tmdbShow.ToListItem()
+			}
 		}
 	}
 	if item == nil {

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -30,7 +30,7 @@ func GetShow(ID string) (show *Show) {
 		URL:    fmt.Sprintf("shows/%s", ID),
 		Header: GetAvailableHeader(),
 		Params: napping.Params{
-			"extended": "full,images",
+			"extended": "full",
 		}.AsUrlValues(),
 		Result:      &show,
 		Description: "trakt show",
@@ -136,7 +136,7 @@ func GetEpisode(showID, seasonNumber, episodeNumber int) (episode *Episode) {
 		API:         reqapi.TraktAPI,
 		URL:         fmt.Sprintf("shows/%d/seasons/%d/episodes/%d", showID, seasonNumber, episodeNumber),
 		Header:      GetAvailableHeader(),
-		Params:      napping.Params{"extended": "full,images"}.AsUrlValues(),
+		Params:      napping.Params{"extended": "full"}.AsUrlValues(),
 		Result:      &episode,
 		Description: "trakt episode",
 
@@ -244,7 +244,7 @@ func SearchShows(query string, page string) (shows []*Shows, err error) {
 			"page":     page,
 			"limit":    strconv.Itoa(config.Get().ResultsPerPage),
 			"query":    query,
-			"extended": "full,images",
+			"extended": "full",
 		}.AsUrlValues(),
 		Result:      &shows,
 		Description: "search show",
@@ -288,7 +288,7 @@ func TopShows(topCategory string, page string) (shows []*Shows, total int, err e
 		Params: napping.Params{
 			"page":     page,
 			"limit":    strconv.Itoa(limit),
-			"extended": "full,images",
+			"extended": "full",
 		}.AsUrlValues(),
 		Result:      &shows,
 		Description: "list shows",
@@ -343,7 +343,7 @@ func WatchlistShows(isUpdateNeeded bool) (shows []*Shows, err error) {
 		URL:    "sync/watchlist/shows",
 		Header: GetAvailableHeader(),
 		Params: napping.Params{
-			"extended": "full,images",
+			"extended": "full",
 		}.AsUrlValues(),
 		Result:      &watchlist,
 		Description: "watchlist shows",
@@ -397,7 +397,7 @@ func CollectionShows(isUpdateNeeded bool) (shows []*Shows, err error) {
 		URL:    "sync/collection/shows",
 		Header: GetAvailableHeader(),
 		Params: napping.Params{
-			"extended": "full,images",
+			"extended": "full",
 		}.AsUrlValues(),
 		Result:      &collection,
 		Description: "collection shows",
@@ -455,7 +455,7 @@ func ListItemsShows(user string, listID string, isUpdateNeeded bool) (shows []*S
 		URL:    fmt.Sprintf("users/%s/lists/%s/items/shows", user, listID),
 		Header: GetAvailableHeader(),
 		Params: napping.Params{
-			"extended": "full,images",
+			"extended": "full",
 		}.AsUrlValues(),
 		Result:      &list,
 		Description: "list item shows",
@@ -509,7 +509,7 @@ func CalendarShows(endPoint string, page string) (shows []*CalendarShow, total i
 		Params: napping.Params{
 			"page":     page,
 			"limit":    strconv.Itoa(limit),
-			"extended": "full,images",
+			"extended": "full",
 		}.AsUrlValues(),
 		Result:      &shows,
 		Description: "calendar shows",
@@ -537,7 +537,7 @@ func WatchedShows(isUpdateNeeded bool) ([]*WatchedShow, error) {
 	var shows []*WatchedShow
 	err := Request(
 		"sync/watched/shows",
-		napping.Params{"extended": "full,images"},
+		napping.Params{"extended": "full"},
 		true,
 		isUpdateNeeded,
 		cache.TraktShowsWatchedKey,

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/elgatito/elementum/cache"
 	"github.com/elgatito/elementum/config"
-	"github.com/elgatito/elementum/fanart"
 	"github.com/elgatito/elementum/library/playcount"
 	"github.com/elgatito/elementum/library/uid"
 	"github.com/elgatito/elementum/tmdb"
@@ -21,64 +20,6 @@ import (
 	"github.com/anacrolix/sync"
 	"github.com/jmcvetta/napping"
 )
-
-// Fill fanart from TMDB
-func setShowFanart(show *Show, tmdbShow *tmdb.Show) *Show {
-	if show.Images == nil {
-		show.Images = &Images{}
-	}
-	if show.Images.Poster == nil {
-		show.Images.Poster = &Sizes{}
-	}
-	if show.Images.Thumbnail == nil {
-		show.Images.Thumbnail = &Sizes{}
-	}
-	if show.Images.FanArt == nil {
-		show.Images.FanArt = &Sizes{}
-	}
-	if show.Images.Banner == nil {
-		show.Images.Banner = &Sizes{}
-	}
-	if show.Images.ClearArt == nil {
-		show.Images.ClearArt = &Sizes{}
-	}
-
-	if show.IDs == nil || show.IDs.TMDB == 0 {
-		return show
-	}
-
-	if tmdbShow == nil {
-		tmdbID := strconv.Itoa(show.IDs.TMDB)
-		tmdbShow = tmdb.GetShowByID(tmdbID, config.Get().Language)
-	}
-	if tmdbShow == nil || tmdbShow.Images == nil {
-		return show
-	}
-
-	if len(tmdbShow.Images.Posters) > 0 {
-		posterImage := tmdb.ImageURL(tmdbShow.Images.Posters[0].FilePath, "w1280")
-		for _, image := range tmdbShow.Images.Posters {
-			if image.Iso639_1 == config.Get().Language {
-				posterImage = tmdb.ImageURL(image.FilePath, "w1280")
-				break
-			}
-		}
-		show.Images.Poster.Full = posterImage
-		show.Images.Thumbnail.Full = posterImage
-	}
-	if len(tmdbShow.Images.Backdrops) > 0 {
-		backdropImage := tmdb.ImageURL(tmdbShow.Images.Backdrops[0].FilePath, "w1280")
-		for _, image := range tmdbShow.Images.Backdrops {
-			if image.Iso639_1 == config.Get().Language {
-				backdropImage = tmdb.ImageURL(image.FilePath, "w1280")
-				break
-			}
-		}
-		show.Images.FanArt.Full = backdropImage
-		show.Images.Banner.Full = backdropImage
-	}
-	return show
-}
 
 // GetShow ...
 func GetShow(ID string) (show *Show) {
@@ -909,86 +850,81 @@ func (show *Show) ToListItem() (item *xbmc.ListItem) {
 }
 
 // ToListItem ...
-func (episode *Episode) ToListItem(show *Show, tmdbShow *tmdb.Show) *xbmc.ListItem {
+func (episode *Episode) ToListItem(show *Show, tmdbShow *tmdb.Show) (item *xbmc.ListItem) {
 	defer perf.ScopeTimer()()
 
-	if show == nil || show.IDs == nil || show.Images == nil || episode == nil || episode.IDs == nil {
+	if show == nil || show.IDs == nil || episode == nil || episode.IDs == nil {
 		return nil
 	}
 
-	episodeLabel := episode.Title
-	if config.Get().AddEpisodeNumbers {
-		episodeLabel = fmt.Sprintf("%dx%02d %s", episode.Season, episode.Number, episode.Title)
+	var tmdbSeason *tmdb.Season
+	var tmdbEpisode *tmdb.Episode
+	if show.IDs.TMDB != 0 {
+		if tmdbShow == nil {
+			tmdbShow = tmdb.GetShow(show.IDs.TMDB, config.Get().Language)
+		}
+
+		if tmdbShow != nil {
+			if tmdbSeason = tmdb.GetSeason(show.IDs.TMDB, episode.Season, config.Get().Language, len(tmdbShow.Seasons), false); tmdbSeason != nil {
+				if tmdbEpisode = tmdb.GetEpisode(show.IDs.TMDB, episode.Season, episode.Number, config.Get().Language); tmdbEpisode != nil {
+					if !config.Get().ForceUseTrakt {
+						item = tmdbEpisode.ToListItem(tmdbShow, tmdbSeason)
+					}
+				}
+			}
+		}
 	}
 
-	runtime := 1800
-	if show.Runtime > 0 {
-		runtime = show.Runtime
-	}
+	if item == nil {
+		episodeLabel := episode.Title
+		if config.Get().AddEpisodeNumbers {
+			episodeLabel = fmt.Sprintf("%dx%02d %s", episode.Season, episode.Number, episode.Title)
+		}
 
-	show = setShowFanart(show, tmdbShow)
-	item := &xbmc.ListItem{
-		Label:  episodeLabel,
-		Label2: fmt.Sprintf("%f", episode.Rating),
-		Info: &xbmc.ListItemInfo{
-			Count:         rand.Int(),
-			Title:         episodeLabel,
-			OriginalTitle: episode.Title,
-			Season:        episode.Season,
-			Episode:       episode.Number,
-			TVShowTitle:   show.Title,
-			Plot:          episode.Overview,
-			PlotOutline:   episode.Overview,
-			Rating:        episode.Rating,
-			Aired:         episode.FirstAired,
-			Duration:      runtime,
-			Genre:         show.Genres,
-			Code:          show.IDs.IMDB,
-			IMDBNumber:    show.IDs.IMDB,
-			PlayCount:     playcount.GetWatchedEpisodeByTMDB(show.IDs.TMDB, episode.Season, episode.Number).Int(),
-			DBTYPE:        "episode",
-			Mediatype:     "episode",
-			Studio:        []string{show.Network},
-		},
-		Art: &xbmc.ListItemArt{
-			TvShowPoster: show.Images.Poster.Full,
-			Poster:       show.Images.Poster.Full,
-			FanArt:       show.Images.FanArt.Full,
-			Banner:       show.Images.Banner.Full,
-			Thumbnail:    show.Images.Thumbnail.Full,
-			ClearArt:     show.Images.ClearArt.Full,
-		},
-		Thumbnail: show.Images.Poster.Full,
-		UniqueIDs: &xbmc.UniqueIDs{
-			TMDB: strconv.Itoa(episode.IDs.TMDB),
-		},
-		Properties: &xbmc.ListItemProperties{
-			ShowTMDBId: strconv.Itoa(show.IDs.TMDB),
-		},
+		runtime := 1800
+		if show.Runtime > 0 {
+			runtime = show.Runtime
+		}
+
+		item = &xbmc.ListItem{
+			Label:  episodeLabel,
+			Label2: fmt.Sprintf("%f", episode.Rating),
+			Info: &xbmc.ListItemInfo{
+				Count:         rand.Int(),
+				Title:         episodeLabel,
+				OriginalTitle: episode.Title,
+				Season:        episode.Season,
+				Episode:       episode.Number,
+				TVShowTitle:   show.Title,
+				Plot:          episode.Overview,
+				PlotOutline:   episode.Overview,
+				Rating:        episode.Rating,
+				Aired:         episode.FirstAired,
+				Duration:      runtime,
+				Genre:         show.Genres,
+				Code:          show.IDs.IMDB,
+				IMDBNumber:    show.IDs.IMDB,
+				PlayCount:     playcount.GetWatchedEpisodeByTMDB(show.IDs.TMDB, episode.Season, episode.Number).Int(),
+				DBTYPE:        "episode",
+				Mediatype:     "episode",
+				Studio:        []string{show.Network},
+			},
+			UniqueIDs: &xbmc.UniqueIDs{
+				TMDB: strconv.Itoa(episode.IDs.TMDB),
+			},
+			Properties: &xbmc.ListItemProperties{
+				ShowTMDBId: strconv.Itoa(show.IDs.TMDB),
+			},
+		}
+		if tmdbEpisode != nil {
+			tmdbEpisode.SetArt(tmdbShow, tmdbSeason, item)
+		}
 	}
 
 	if ls, err := uid.GetShowByTMDB(show.IDs.TMDB); ls != nil && err == nil {
 		if le := ls.GetEpisode(episode.Season, episode.Number); le != nil {
 			item.Info.DBID = le.UIDs.Kodi
 		}
-	}
-
-	if config.Get().UseFanartTv {
-		if fa := fanart.GetShow(util.StrInterfaceToInt(show.IDs.TVDB)); fa != nil {
-			item.Art = fa.ToEpisodeListItemArt(episode.Season, item.Art)
-		}
-	}
-
-	if episode.Images != nil && episode.Images.ScreenShot.Full != "" {
-		item.Art.FanArt = episode.Images.ScreenShot.Full
-		item.Art.Thumbnail = episode.Images.ScreenShot.Full
-		item.Art.Poster = episode.Images.ScreenShot.Full
-		item.Thumbnail = episode.Images.ScreenShot.Full
-	} else if epi := tmdb.GetEpisode(show.IDs.TMDB, episode.Season, episode.Number, config.Get().Language); epi != nil && epi.StillPath != "" {
-		item.Art.FanArt = tmdb.ImageURL(epi.StillPath, "w1280")
-		item.Art.Thumbnail = tmdb.ImageURL(epi.StillPath, "w1280")
-		item.Art.Poster = tmdb.ImageURL(epi.StillPath, "w1280")
-		item.Thumbnail = tmdb.ImageURL(epi.StillPath, "w1280")
 	}
 
 	return item

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -848,18 +848,11 @@ func (show *Show) ToListItem() (item *xbmc.ListItem) {
 
 	var tmdbShow *tmdb.Show
 	if show.IDs.TMDB != 0 {
-		tmdbID := strconv.Itoa(show.IDs.TMDB)
-		if tmdbShow = tmdb.GetShowByID(tmdbID, config.Get().Language); tmdbShow != nil && !config.Get().ForceUseTrakt {
+		if tmdbShow = tmdb.GetShow(show.IDs.TMDB, config.Get().Language); tmdbShow != nil && !config.Get().ForceUseTrakt {
 			item = tmdbShow.ToListItem()
 		}
 	}
 	if item == nil {
-		show = setShowFanart(show, tmdbShow)
-
-		if show == nil || show.IDs == nil || show.Images == nil {
-			return
-		}
-
 		item = &xbmc.ListItem{
 			Label: show.Title,
 			Info: &xbmc.ListItemInfo{
@@ -885,18 +878,12 @@ func (show *Show) ToListItem() (item *xbmc.ListItem) {
 			Properties: &xbmc.ListItemProperties{
 				TotalEpisodes: strconv.Itoa(show.AiredEpisodes),
 			},
-			Art: &xbmc.ListItemArt{
-				TvShowPoster: show.Images.Poster.Full,
-				Poster:       show.Images.Poster.Full,
-				FanArt:       show.Images.FanArt.Full,
-				Banner:       show.Images.Banner.Full,
-				Thumbnail:    show.Images.Thumbnail.Full,
-				ClearArt:     show.Images.ClearArt.Full,
-			},
-			Thumbnail: show.Images.Poster.Full,
 			UniqueIDs: &xbmc.UniqueIDs{
 				TMDB: strconv.Itoa(show.IDs.TMDB),
 			},
+		}
+		if tmdbShow != nil {
+			tmdbShow.SetArt(item)
 		}
 	}
 
@@ -912,16 +899,6 @@ func (show *Show) ToListItem() (item *xbmc.ListItem) {
 		watchedEpisodes := tmdbShow.CountWatchedEpisodesNumber()
 		item.Properties.WatchedEpisodes = strconv.Itoa(watchedEpisodes)
 		item.Properties.UnWatchedEpisodes = strconv.Itoa(totalEpisodes - watchedEpisodes)
-	}
-
-	if item.Art != nil {
-		item.Thumbnail = item.Art.Poster
-		// item.Art.Thumbnail = item.Art.Poster
-
-		// if fa := fanart.GetShow(util.StrInterfaceToInt(show.IDs.TVDB)); fa != nil {
-		// 	item.Art = fa.ToListItemArt(item.Art)
-		// 	item.Thumbnail = item.Art.Thumbnail
-		// }
 	}
 
 	if len(item.Info.Trailer) == 0 {

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -138,7 +138,6 @@ type Season struct {
 	Network       string  `json:"network"`
 
 	Episodes []*Episode `json:"episodes"`
-	Images   *Images    `json:"images"`
 	IDs      *IDs       `json:"ids"`
 }
 

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -123,8 +123,6 @@ type Show struct {
 	Country       string   `json:"country"`
 	Language      string   `json:"language"`
 	Translations  []string `json:"available_translations"`
-
-	Images *Images `json:"images"`
 }
 
 // Season ...

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -157,8 +157,7 @@ type Episode struct {
 	Rating  float32 `json:"rating"`
 	Votes   int     `json:"votes"`
 
-	Images *Images `json:"images"`
-	IDs    *IDs    `json:"ids"`
+	IDs *IDs `json:"ids"`
 }
 
 // Airs ...
@@ -247,19 +246,6 @@ type HiddenShow struct {
 	HiddenAt time.Time `json:"hidden_at"`
 	Type     string    `json:"type"`
 	Show     *Show     `json:"show"`
-}
-
-// Images ...
-type Images struct {
-	Poster     *Sizes `json:"poster"`
-	FanArt     *Sizes `json:"fanart"`
-	ScreenShot *Sizes `json:"screenshot"`
-	HeadShot   *Sizes `json:"headshot"`
-	Logo       *Sizes `json:"logo"`
-	ClearArt   *Sizes `json:"clearart"`
-	Banner     *Sizes `json:"banner"`
-	Thumbnail  *Sizes `json:"thumb"`
-	Avatar     *Sizes `json:"avatar"`
 }
 
 // Sizes ...

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -101,8 +101,6 @@ type Movie struct {
 	Genres        []string `json:"genres"`
 	Language      string   `json:"language"`
 	Translations  []string `json:"available_translations"`
-
-	Images *Images `json:"images"`
 }
 
 // Show ...


### PR DESCRIPTION
Trakt does not return images for a long time and thus we anyway use tmdb api to get images, so it makes sense to move all the code to `tmdb` package. 
Also it solves the issue that trakt code was not using fanart.tv (`UseFanartTv`) and did not set `AvailableArtworks` property (for skins).
Also now it prefers language specific arts (was implemented in trakt code but not in tmdb code).

Proof:
"images" field in trakt response is gone long time ago, see https://github.com/scakemyer/plugin.video.quasar/issues/599#issuecomment-268933889

also see their announce https://apiblog.trakt.tv/how-to-find-the-best-images-516045bcc3b6

or run:
```
curl -s -H @trakt-headers.txt https://api.trakt.tv/shows/supernatural/seasons/1/episodes/1?extended=full,images| jq
curl -s -H @trakt-headers.txt https://api.trakt.tv/movies/the-flash-2023?extended=full,images| jq
```
```
  "images": {
    "fanart": {
      "full": null,
      "medium": null,
      "thumb": null
    },
    "poster": {
      "full": null,
      "medium": null,
      "thumb": null
    },
    "logo": {
      "full": null
    },
    "clearart": {
      "full": null
    },
    "banner": {
      "full": null
    },
    "thumb": {
      "full": null
    }
  }
```

---

also should close https://github.com/elgatito/plugin.video.elementum/issues/955 for good since now there is no difference about images for tmdb and trakt.

---

documentation:
https://kodi.wiki/view/Artwork_types
https://kodi.wiki/view/InfoLabels
https://alwinesch.github.io/group__python__xbmcgui__listitem.html#gad5dfc6f76921e0127594d1744685eb56

https://trakt.docs.apiary.io/#introduction/images

https://fanarttv.docs.apiary.io/#reference/movies/get-images-for-movie?console=1

https://developer.themoviedb.org/docs/image-languages
