### PR TITLE
Improve trakt calendars usability

### DIFF
--- a/api/shows.go
+++ b/api/shows.go
@@ -565,7 +565,7 @@ func ShowEpisodes(ctx *gin.Context) {
 				continue
 			}
 			if !config.Get().ShowUnairedSeasons {
-				if _, isExpired := util.AirDateWithExpireCheck(s.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); isExpired {
+				if _, isAired := util.AirDateWithAiredCheck(s.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); !isAired {
 					continue
 				}
 			}

--- a/api/trakt.go
+++ b/api/trakt.go
@@ -995,7 +995,17 @@ func TraktMyShows(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	shows, total, err := trakt.CalendarShows("my/shows", pageParam, cache.TraktShowsCalendarMyExpire)
+
+	lastActivities, err := trakt.GetLastActivities()
+	previousActivities, _ := trakt.GetPreviousActivities()
+
+	isUpdateNeeded := err != nil ||
+		lastActivities.Shows.WatchlistedAt.After(previousActivities.Shows.WatchlistedAt) ||
+		lastActivities.Episodes.WatchlistedAt.After(previousActivities.Episodes.WatchlistedAt) ||
+		lastActivities.Episodes.CollectedAt.After(previousActivities.Episodes.CollectedAt) ||
+		lastActivities.Episodes.WatchedAt.After(previousActivities.Episodes.WatchedAt)
+
+	shows, total, err := trakt.CalendarShows("my/shows", pageParam, cache.TraktShowsCalendarMyExpire, isUpdateNeeded)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1011,7 +1021,17 @@ func TraktMyNewShows(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	shows, total, err := trakt.CalendarShows("my/shows/new", pageParam, cache.TraktShowsCalendarMyExpire)
+
+	lastActivities, err := trakt.GetLastActivities()
+	previousActivities, _ := trakt.GetPreviousActivities()
+
+	isUpdateNeeded := err != nil ||
+		lastActivities.Shows.WatchlistedAt.After(previousActivities.Shows.WatchlistedAt) ||
+		lastActivities.Episodes.WatchlistedAt.After(previousActivities.Episodes.WatchlistedAt) ||
+		lastActivities.Episodes.CollectedAt.After(previousActivities.Episodes.CollectedAt) ||
+		lastActivities.Episodes.WatchedAt.After(previousActivities.Episodes.WatchedAt)
+
+	shows, total, err := trakt.CalendarShows("my/shows/new", pageParam, cache.TraktShowsCalendarMyExpire, isUpdateNeeded)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1027,7 +1047,17 @@ func TraktMyPremieres(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	shows, total, err := trakt.CalendarShows("my/shows/premieres", pageParam, cache.TraktShowsCalendarMyExpire)
+
+	lastActivities, err := trakt.GetLastActivities()
+	previousActivities, _ := trakt.GetPreviousActivities()
+
+	isUpdateNeeded := err != nil ||
+		lastActivities.Shows.WatchlistedAt.After(previousActivities.Shows.WatchlistedAt) ||
+		lastActivities.Episodes.WatchlistedAt.After(previousActivities.Episodes.WatchlistedAt) ||
+		lastActivities.Episodes.CollectedAt.After(previousActivities.Episodes.CollectedAt) ||
+		lastActivities.Episodes.WatchedAt.After(previousActivities.Episodes.WatchedAt)
+
+	shows, total, err := trakt.CalendarShows("my/shows/premieres", pageParam, cache.TraktShowsCalendarMyExpire, isUpdateNeeded)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1043,7 +1073,17 @@ func TraktMyMovies(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	movies, total, err := trakt.CalendarMovies("my/movies", pageParam, cache.TraktMoviesCalendarMyExpire)
+
+	lastActivities, err := trakt.GetLastActivities()
+	previousActivities, _ := trakt.GetPreviousActivities()
+
+	isUpdateNeeded := err != nil ||
+		lastActivities.Movies.WatchlistedAt.After(previousActivities.Movies.WatchlistedAt) ||
+		lastActivities.Movies.CollectedAt.After(previousActivities.Movies.CollectedAt)
+
+	log.Debug(isUpdateNeeded)
+
+	movies, total, err := trakt.CalendarMovies("my/movies", pageParam, cache.TraktMoviesCalendarMyExpire, isUpdateNeeded)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1059,7 +1099,15 @@ func TraktMyReleases(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	movies, total, err := trakt.CalendarMovies("my/dvd", pageParam, cache.TraktMoviesCalendarMyExpire)
+
+	lastActivities, err := trakt.GetLastActivities()
+	previousActivities, _ := trakt.GetPreviousActivities()
+
+	isUpdateNeeded := err != nil ||
+		lastActivities.Movies.WatchlistedAt.After(previousActivities.Movies.WatchlistedAt) ||
+		lastActivities.Movies.CollectedAt.After(previousActivities.Movies.CollectedAt)
+
+	movies, total, err := trakt.CalendarMovies("my/dvd", pageParam, cache.TraktMoviesCalendarMyExpire, isUpdateNeeded)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1075,7 +1123,7 @@ func TraktAllShows(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	shows, total, err := trakt.CalendarShows("all/shows", pageParam, cache.TraktShowsCalendarAllExpire)
+	shows, total, err := trakt.CalendarShows("all/shows", pageParam, cache.TraktShowsCalendarAllExpire, false)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1091,7 +1139,7 @@ func TraktAllNewShows(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	shows, total, err := trakt.CalendarShows("all/shows/new", pageParam, cache.TraktShowsCalendarAllExpire)
+	shows, total, err := trakt.CalendarShows("all/shows/new", pageParam, cache.TraktShowsCalendarAllExpire, false)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1107,7 +1155,7 @@ func TraktAllPremieres(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	shows, total, err := trakt.CalendarShows("all/shows/premieres", pageParam, cache.TraktShowsCalendarAllExpire)
+	shows, total, err := trakt.CalendarShows("all/shows/premieres", pageParam, cache.TraktShowsCalendarAllExpire, false)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1123,7 +1171,7 @@ func TraktAllMovies(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	movies, total, err := trakt.CalendarMovies("all/movies", pageParam, cache.TraktMoviesCalendarAllExpire)
+	movies, total, err := trakt.CalendarMovies("all/movies", pageParam, cache.TraktMoviesCalendarAllExpire, false)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1139,7 +1187,7 @@ func TraktAllReleases(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	movies, total, err := trakt.CalendarMovies("all/dvd", pageParam, cache.TraktMoviesCalendarAllExpire)
+	movies, total, err := trakt.CalendarMovies("all/dvd", pageParam, cache.TraktMoviesCalendarAllExpire, false)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())

--- a/api/trakt.go
+++ b/api/trakt.go
@@ -1147,7 +1147,7 @@ func TraktAllReleases(ctx *gin.Context) {
 	renderCalendarMovies(ctx, movies, total, page, true)
 }
 
-func renderCalendarMovies(ctx *gin.Context, movies []*trakt.CalendarMovie, total int, page int, dvd bool) {
+func renderCalendarMovies(ctx *gin.Context, movies []*trakt.CalendarMovie, total int, page int, isDVD bool) {
 	hasNextPage := 0
 	if page > 0 {
 		resultsPerPage := config.Get().ResultsPerPage
@@ -1196,7 +1196,7 @@ func renderCalendarMovies(ctx *gin.Context, movies []*trakt.CalendarMovie, total
 			var movie *tmdb.Movie
 			movieName := movieListing.Movie.Title
 			airDate := movieListing.Movie.Released
-			if dvd {
+			if isDVD {
 				airDate = movieListing.Released
 			}
 

--- a/api/trakt.go
+++ b/api/trakt.go
@@ -995,7 +995,7 @@ func TraktMyShows(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	shows, total, err := trakt.CalendarShows("my/shows", pageParam)
+	shows, total, err := trakt.CalendarShows("my/shows", pageParam, cache.TraktShowsCalendarMyExpire)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1011,7 +1011,7 @@ func TraktMyNewShows(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	shows, total, err := trakt.CalendarShows("my/shows/new", pageParam)
+	shows, total, err := trakt.CalendarShows("my/shows/new", pageParam, cache.TraktShowsCalendarMyExpire)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1027,7 +1027,7 @@ func TraktMyPremieres(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	shows, total, err := trakt.CalendarShows("my/shows/premieres", pageParam)
+	shows, total, err := trakt.CalendarShows("my/shows/premieres", pageParam, cache.TraktShowsCalendarMyExpire)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1043,7 +1043,7 @@ func TraktMyMovies(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	movies, total, err := trakt.CalendarMovies("my/movies", pageParam)
+	movies, total, err := trakt.CalendarMovies("my/movies", pageParam, cache.TraktMoviesCalendarMyExpire)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1059,7 +1059,7 @@ func TraktMyReleases(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	movies, total, err := trakt.CalendarMovies("my/dvd", pageParam)
+	movies, total, err := trakt.CalendarMovies("my/dvd", pageParam, cache.TraktMoviesCalendarMyExpire)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1075,7 +1075,7 @@ func TraktAllShows(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	shows, total, err := trakt.CalendarShows("all/shows", pageParam)
+	shows, total, err := trakt.CalendarShows("all/shows", pageParam, cache.TraktShowsCalendarAllExpire)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1091,7 +1091,7 @@ func TraktAllNewShows(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	shows, total, err := trakt.CalendarShows("all/shows/new", pageParam)
+	shows, total, err := trakt.CalendarShows("all/shows/new", pageParam, cache.TraktShowsCalendarAllExpire)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1107,7 +1107,7 @@ func TraktAllPremieres(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	shows, total, err := trakt.CalendarShows("all/shows/premieres", pageParam)
+	shows, total, err := trakt.CalendarShows("all/shows/premieres", pageParam, cache.TraktShowsCalendarAllExpire)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1123,7 +1123,7 @@ func TraktAllMovies(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	movies, total, err := trakt.CalendarMovies("all/movies", pageParam)
+	movies, total, err := trakt.CalendarMovies("all/movies", pageParam, cache.TraktMoviesCalendarAllExpire)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
@@ -1139,7 +1139,7 @@ func TraktAllReleases(ctx *gin.Context) {
 
 	pageParam := ctx.DefaultQuery("page", "1")
 	page, _ := strconv.Atoi(pageParam)
-	movies, total, err := trakt.CalendarMovies("all/dvd", pageParam)
+	movies, total, err := trakt.CalendarMovies("all/dvd", pageParam, cache.TraktMoviesCalendarAllExpire)
 
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())

--- a/api/trakt.go
+++ b/api/trakt.go
@@ -1625,14 +1625,14 @@ func renderProgressShows(ctx *gin.Context, shows []*trakt.ProgressShow, total in
 		})
 	} else if config.Get().TraktProgressSort == trakt.ProgressSortAiredNewer {
 		sort.Slice(items, func(i, j int) bool {
-			id, _ := time.Parse("2006-01-02", items[i].Info.Aired)
-			jd, _ := time.Parse("2006-01-02", items[j].Info.Aired)
+			id, _ := time.Parse(time.DateOnly, items[i].Info.Aired)
+			jd, _ := time.Parse(time.DateOnly, items[j].Info.Aired)
 			return id.After(jd)
 		})
 	} else if config.Get().TraktProgressSort == trakt.ProgressSortAiredOlder {
 		sort.Slice(items, func(i, j int) bool {
-			id, _ := time.Parse("2006-01-02", items[i].Info.Aired)
-			jd, _ := time.Parse("2006-01-02", items[j].Info.Aired)
+			id, _ := time.Parse(time.DateOnly, items[i].Info.Aired)
+			jd, _ := time.Parse(time.DateOnly, items[j].Info.Aired)
 			return id.Before(jd)
 		})
 	}

--- a/api/trakt.go
+++ b/api/trakt.go
@@ -1549,7 +1549,7 @@ func renderProgressShows(ctx *gin.Context, shows []*trakt.ProgressShow, total in
 			}
 
 			aired, isAired := util.AirDateWithAiredCheck(airDate, airDateFormat, config.Get().ShowEpisodesOnReleaseDay)
-			if config.Get().TraktProgressUnaired && !isAired {
+			if config.Get().TraktProgressHideUnaired && !isAired {
 				return
 			}
 

--- a/api/trakt.go
+++ b/api/trakt.go
@@ -1048,7 +1048,7 @@ func TraktMyMovies(ctx *gin.Context) {
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
 	}
-	renderCalendarMovies(ctx, movies, total, page)
+	renderCalendarMovies(ctx, movies, total, page, false)
 }
 
 // TraktMyReleases ...
@@ -1064,7 +1064,7 @@ func TraktMyReleases(ctx *gin.Context) {
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
 	}
-	renderCalendarMovies(ctx, movies, total, page)
+	renderCalendarMovies(ctx, movies, total, page, true)
 }
 
 // TraktAllShows ...
@@ -1128,7 +1128,7 @@ func TraktAllMovies(ctx *gin.Context) {
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
 	}
-	renderCalendarMovies(ctx, movies, total, page)
+	renderCalendarMovies(ctx, movies, total, page, false)
 }
 
 // TraktAllReleases ...
@@ -1144,10 +1144,10 @@ func TraktAllReleases(ctx *gin.Context) {
 	if err != nil {
 		xbmcHost.Notify("Elementum", err.Error(), config.AddonIcon())
 	}
-	renderCalendarMovies(ctx, movies, total, page)
+	renderCalendarMovies(ctx, movies, total, page, true)
 }
 
-func renderCalendarMovies(ctx *gin.Context, movies []*trakt.CalendarMovie, total int, page int) {
+func renderCalendarMovies(ctx *gin.Context, movies []*trakt.CalendarMovie, total int, page int, dvd bool) {
 	hasNextPage := 0
 	if page > 0 {
 		resultsPerPage := config.Get().ResultsPerPage
@@ -1193,6 +1193,10 @@ func renderCalendarMovies(ctx *gin.Context, movies []*trakt.CalendarMovie, total
 			var movie *tmdb.Movie
 			movieName := movieListing.Movie.Title
 			airDate := movieListing.Movie.Released
+			if dvd {
+				airDate = movieListing.Released
+			}
+
 			if len(airDate) > 10 && strings.Contains(airDate, "T") {
 				airDate = airDate[0:strings.Index(airDate, "T")]
 			}

--- a/api/trakt.go
+++ b/api/trakt.go
@@ -1498,7 +1498,6 @@ func renderProgressShows(ctx *gin.Context, shows []*trakt.ProgressShow, total in
 	dateFormat := getProgressDateFormat()
 
 	items := make(xbmc.ListItems, len(shows))
-	now := util.UTCBod()
 
 	wg := sync.WaitGroup{}
 	wg.Add(len(shows))
@@ -1549,13 +1548,13 @@ func renderProgressShows(ctx *gin.Context, shows []*trakt.ProgressShow, total in
 				}
 			}
 
-			aired, isExpired := util.AirDateWithExpireCheck(airDate, airDateFormat, config.Get().ShowEpisodesOnReleaseDay)
-			if config.Get().TraktProgressUnaired && isExpired {
+			aired, isAired := util.AirDateWithAiredCheck(airDate, airDateFormat, config.Get().ShowEpisodesOnReleaseDay)
+			if config.Get().TraktProgressUnaired && !isAired {
 				return
 			}
 
 			localEpisodeColor := colorEpisode
-			if aired.After(now) || aired.Equal(now) {
+			if !isAired {
 				localEpisodeColor = colorUnaired
 			}
 

--- a/cache/types.go
+++ b/cache/types.go
@@ -74,7 +74,8 @@ const (
 	TraktMoviesListKey                     = TraktKey + "movies.list.%s"
 	TraktMoviesListExpire                  = 1 * time.Minute
 	TraktMoviesCalendarKey                 = TraktKey + "movies.calendar.%s.%s.%d"
-	TraktMoviesCalendarExpire              = CacheExpireLong
+	TraktMoviesCalendarAllExpire           = CacheExpireLong
+	TraktMoviesCalendarMyExpire            = CacheExpireShort
 	TraktMoviesCalendarTotalKey            = TraktKey + "movies.calendar.%s.total"
 	TraktMoviesCalendarTotalExpire         = CacheExpireLong
 	TraktMoviesWatchedKey                  = TraktKey + "movies.watched"
@@ -98,7 +99,8 @@ const (
 	TraktShowsListKey                      = TraktKey + "shows.list.%s"
 	TraktShowsListExpire                   = CacheExpireLong
 	TraktShowsCalendarKey                  = TraktKey + "shows.calendar.%s.%s.%d"
-	TraktShowsCalendarExpire               = CacheExpireLong
+	TraktShowsCalendarAllExpire            = CacheExpireLong
+	TraktShowsCalendarMyExpire             = CacheExpireShort
 	TraktShowsCalendarTotalKey             = TraktKey + "shows.calendar.%s.total"
 	TraktShowsCalendarTotalExpire          = CacheExpireLong
 	TraktShowsHiddenProgressKey            = TraktKey + "shows.hidden.progress"

--- a/cache/types.go
+++ b/cache/types.go
@@ -99,8 +99,8 @@ const (
 	TraktShowsListKey                      = TraktKey + "shows.list.%s"
 	TraktShowsListExpire                   = CacheExpireLong
 	TraktShowsCalendarKey                  = TraktKey + "shows.calendar.%s.%s.%d"
-	TraktShowsCalendarAllExpire            = CacheExpireLong
-	TraktShowsCalendarMyExpire             = CacheExpireShort
+	TraktShowsCalendarAllExpire            = CacheExpireExtra
+	TraktShowsCalendarMyExpire             = CacheExpireLong
 	TraktShowsCalendarTotalKey             = TraktKey + "shows.calendar.%s.total"
 	TraktShowsCalendarTotalExpire          = CacheExpireLong
 	TraktShowsHiddenProgressKey            = TraktKey + "shows.hidden.progress"

--- a/config/config.go
+++ b/config/config.go
@@ -196,7 +196,7 @@ type Configuration struct {
 	TraktSyncRemovedShowsBack      bool
 	TraktSyncRemovedShowsLocation  int
 	TraktSyncRemovedShowsList      int
-	TraktProgressUnaired           bool
+	TraktProgressHideUnaired       bool
 	TraktProgressSort              int
 	TraktProgressDateFormat        string
 	TraktProgressColorDate         string
@@ -677,7 +677,7 @@ func Reload() (ret *Configuration, err error) {
 		TraktSyncRemovedShowsBack:      settings.ToBool("trakt_sync_removed_shows_back"),
 		TraktSyncRemovedShowsLocation:  settings.ToInt("trakt_sync_removed_shows_location"),
 		TraktSyncRemovedShowsList:      settings.ToInt("trakt_sync_removed_shows_list"),
-		TraktProgressUnaired:           settings.ToBool("trakt_progress_unaired"),
+		TraktProgressHideUnaired:       settings.ToBool("trakt_progress_hide_unaired"),
 		TraktProgressSort:              settings.ToInt("trakt_progress_sort"),
 		TraktProgressDateFormat:        settings.ToString("trakt_progress_date_format"),
 		TraktProgressColorDate:         settings.ToString("trakt_progress_color_date"),

--- a/config/config.go
+++ b/config/config.go
@@ -203,6 +203,7 @@ type Configuration struct {
 	TraktProgressColorShow         string
 	TraktProgressColorEpisode      string
 	TraktProgressColorUnaired      string
+	TraktCalendarsHideWatched      bool
 	TraktCalendarsDateFormat       string
 	TraktCalendarsColorDate        string
 	TraktCalendarsColorShow        string
@@ -684,6 +685,7 @@ func Reload() (ret *Configuration, err error) {
 		TraktProgressColorShow:         settings.ToString("trakt_progress_color_show"),
 		TraktProgressColorEpisode:      settings.ToString("trakt_progress_color_episode"),
 		TraktProgressColorUnaired:      settings.ToString("trakt_progress_color_unaired"),
+		TraktCalendarsHideWatched:      settings.ToBool("trakt_calendars_hide_watched"),
 		TraktCalendarsDateFormat:       settings.ToString("trakt_calendars_date_format"),
 		TraktCalendarsColorDate:        settings.ToString("trakt_calendars_color_date"),
 		TraktCalendarsColorShow:        settings.ToString("trakt_calendars_color_show"),

--- a/library/library.go
+++ b/library/library.go
@@ -576,7 +576,7 @@ func writeShowStrm(showID int, adding, force bool) (*tmdb.Show, error) {
 			continue
 		}
 		if !config.Get().ShowUnairedSeasons {
-			if _, isExpired := util.AirDateWithExpireCheck(season.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); isExpired {
+			if _, isAired := util.AirDateWithAiredCheck(season.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); !isAired {
 				continue
 			}
 		}
@@ -600,7 +600,7 @@ func writeShowStrm(showID int, adding, force bool) (*tmdb.Show, error) {
 				if episode.AirDate == "" {
 					continue
 				}
-				if _, isExpired := util.AirDateWithExpireCheck(episode.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); isExpired {
+				if _, isAired := util.AirDateWithAiredCheck(episode.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); !isAired {
 					continue
 				}
 			}

--- a/library/refresh.go
+++ b/library/refresh.go
@@ -654,7 +654,7 @@ func parseUniqueID(entityType int, i *uid.UniqueIDs, xbmcIDs *xbmc.UniqueIDs, fi
 		if entityType == MovieType {
 			m := tmdb.GetMovie(localID, config.Get().Language)
 			if m != nil {
-				dt, err := time.Parse("2006-01-02", m.FirstAirDate)
+				dt, err := time.Parse(time.DateOnly, m.FirstAirDate)
 				if err != nil || dt.Year() == entityYear {
 					i.TMDB = m.ID
 					return
@@ -663,7 +663,7 @@ func parseUniqueID(entityType int, i *uid.UniqueIDs, xbmcIDs *xbmc.UniqueIDs, fi
 		} else if entityType == ShowType {
 			s := tmdb.GetShow(localID, config.Get().Language)
 			if s != nil {
-				dt, err := time.Parse("2006-01-02", s.FirstAirDate)
+				dt, err := time.Parse(time.DateOnly, s.FirstAirDate)
 				if err != nil || dt.Year() == entityYear {
 					i.TMDB = s.ID
 					return
@@ -753,7 +753,7 @@ func findTMDBIDsWithYear(entityType int, source string, id string, year int) int
 	if results != nil {
 		if entityType == MovieType && len(results.MovieResults) > 0 {
 			for _, e := range results.MovieResults {
-				dt, err := time.Parse("2006-01-02", e.FirstAirDate)
+				dt, err := time.Parse(time.DateOnly, e.FirstAirDate)
 				if err != nil || year == 0 || dt.Year() == 0 {
 					reserveID = e.ID
 					continue
@@ -764,7 +764,7 @@ func findTMDBIDsWithYear(entityType int, source string, id string, year int) int
 			}
 		} else if entityType == ShowType && len(results.TVResults) > 0 {
 			for _, e := range results.TVResults {
-				dt, err := time.Parse("2006-01-02", e.FirstAirDate)
+				dt, err := time.Parse(time.DateOnly, e.FirstAirDate)
 				if err != nil || year == 0 || dt.Year() == 0 {
 					reserveID = e.ID
 					continue
@@ -775,7 +775,7 @@ func findTMDBIDsWithYear(entityType int, source string, id string, year int) int
 			}
 		} else if entityType == EpisodeType && len(results.TVEpisodeResults) > 0 {
 			for _, e := range results.TVEpisodeResults {
-				dt, err := time.Parse("2006-01-02", e.FirstAirDate)
+				dt, err := time.Parse(time.DateOnly, e.FirstAirDate)
 				if err != nil || year == 0 || dt.Year() == 0 {
 					reserveID = e.ID
 					continue

--- a/tmdb/episode.go
+++ b/tmdb/episode.go
@@ -69,7 +69,7 @@ func (episodes EpisodeList) ToListItems(show *Show, season *Season) []*xbmc.List
 			if episode.AirDate == "" {
 				continue
 			}
-			if _, isExpired := util.AirDateWithExpireCheck(episode.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); isExpired {
+			if _, isAired := util.AirDateWithAiredCheck(episode.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); !isAired {
 				continue
 			}
 		}

--- a/tmdb/movie.go
+++ b/tmdb/movie.go
@@ -311,28 +311,28 @@ func PopularMovies(params DiscoverFilters, language string, page int) (Movies, i
 		p = napping.Params{
 			"language":                 language,
 			"sort_by":                  "popularity.desc",
-			"primary_release_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"primary_release_date.lte": time.Now().UTC().Format(time.DateOnly),
 			"with_genres":              params.Genre,
 		}
 	} else if params.Country != "" {
 		p = napping.Params{
 			"language":                 language,
 			"sort_by":                  "popularity.desc",
-			"primary_release_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"primary_release_date.lte": time.Now().UTC().Format(time.DateOnly),
 			"with_origin_country":      params.Country,
 		}
 	} else if params.Language != "" {
 		p = napping.Params{
 			"language":                 language,
 			"sort_by":                  "popularity.desc",
-			"primary_release_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"primary_release_date.lte": time.Now().UTC().Format(time.DateOnly),
 			"with_original_language":   params.Language,
 		}
 	} else {
 		p = napping.Params{
 			"language":                 language,
 			"sort_by":                  "popularity.desc",
-			"primary_release_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"primary_release_date.lte": time.Now().UTC().Format(time.DateOnly),
 		}
 	}
 
@@ -347,7 +347,7 @@ func RecentMovies(params DiscoverFilters, language string, page int) (Movies, in
 			"language":                 language,
 			"sort_by":                  "primary_release_date.desc",
 			"vote_count.gte":           "10",
-			"primary_release_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"primary_release_date.lte": time.Now().UTC().Format(time.DateOnly),
 			"with_genres":              params.Genre,
 		}
 	} else if params.Country != "" {
@@ -355,7 +355,7 @@ func RecentMovies(params DiscoverFilters, language string, page int) (Movies, in
 			"language":                 language,
 			"sort_by":                  "primary_release_date.desc",
 			"vote_count.gte":           "10",
-			"primary_release_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"primary_release_date.lte": time.Now().UTC().Format(time.DateOnly),
 			"region":                   params.Country,
 		}
 	} else if params.Language != "" {
@@ -363,7 +363,7 @@ func RecentMovies(params DiscoverFilters, language string, page int) (Movies, in
 			"language":                 language,
 			"sort_by":                  "primary_release_date.desc",
 			"vote_count.gte":           "10",
-			"primary_release_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"primary_release_date.lte": time.Now().UTC().Format(time.DateOnly),
 			"with_original_language":   params.Language,
 		}
 	} else {
@@ -371,7 +371,7 @@ func RecentMovies(params DiscoverFilters, language string, page int) (Movies, in
 			"language":                 language,
 			"sort_by":                  "primary_release_date.desc",
 			"vote_count.gte":           "10",
-			"primary_release_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"primary_release_date.lte": time.Now().UTC().Format(time.DateOnly),
 		}
 	}
 
@@ -390,13 +390,13 @@ func MostVotedMovies(genre string, language string, page int) (Movies, int) {
 		p = napping.Params{
 			"language":                 language,
 			"sort_by":                  "vote_count.desc",
-			"primary_release_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"primary_release_date.lte": time.Now().UTC().Format(time.DateOnly),
 		}
 	} else {
 		p = napping.Params{
 			"language":                 language,
 			"sort_by":                  "vote_count.desc",
-			"primary_release_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"primary_release_date.lte": time.Now().UTC().Format(time.DateOnly),
 			"with_genres":              genre,
 		}
 	}

--- a/tmdb/season.go
+++ b/tmdb/season.go
@@ -115,7 +115,7 @@ func (seasons SeasonList) ToListItems(show *Show) []*xbmc.ListItem {
 		}
 
 		if !config.Get().ShowUnairedSeasons {
-			if _, isExpired := util.AirDateWithExpireCheck(season.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); isExpired {
+			if _, isAired := util.AirDateWithAiredCheck(season.AirDate, time.DateOnly, config.Get().ShowEpisodesOnReleaseDay); !isAired {
 				continue
 			}
 		}
@@ -337,7 +337,7 @@ func (season *Season) countWatchedEpisodesNumber(show *Show) (watchedEpisodes in
 				if episode.AirDate == "" {
 					continue
 				}
-				if _, isExpired := util.AirDateWithExpireCheck(episode.AirDate, time.DateOnly, c.ShowEpisodesOnReleaseDay); isExpired {
+				if _, isAired := util.AirDateWithAiredCheck(episode.AirDate, time.DateOnly, c.ShowEpisodesOnReleaseDay); !isAired {
 					continue
 				}
 			}
@@ -377,7 +377,7 @@ func (season *Season) countEpisodesNumber(show *Show) (episodes int) {
 				if episode.AirDate == "" {
 					continue
 				}
-				if _, isExpired := util.AirDateWithExpireCheck(episode.AirDate, time.DateOnly, c.ShowEpisodesOnReleaseDay); isExpired {
+				if _, isAired := util.AirDateWithAiredCheck(episode.AirDate, time.DateOnly, c.ShowEpisodesOnReleaseDay); !isAired {
 					continue
 				}
 			}

--- a/tmdb/show.go
+++ b/tmdb/show.go
@@ -770,7 +770,7 @@ func (show *Show) CountRealSeasons() int {
 		}
 
 		if !c.ShowUnairedSeasons {
-			if _, isExpired := util.AirDateWithExpireCheck(s.AirDate, time.DateOnly, c.ShowEpisodesOnReleaseDay); isExpired {
+			if _, isAired := util.AirDateWithAiredCheck(s.AirDate, time.DateOnly, c.ShowEpisodesOnReleaseDay); !isAired {
 				continue
 			}
 		}

--- a/tmdb/show.go
+++ b/tmdb/show.go
@@ -271,28 +271,28 @@ func PopularShows(params DiscoverFilters, language string, page int) (Shows, int
 		p = napping.Params{
 			"language":           language,
 			"sort_by":            "popularity.desc",
-			"first_air_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"first_air_date.lte": time.Now().UTC().Format(time.DateOnly),
 			"with_genres":        params.Genre,
 		}
 	} else if params.Country != "" {
 		p = napping.Params{
 			"language":            language,
 			"sort_by":             "popularity.desc",
-			"first_air_date.lte":  time.Now().UTC().Format("2006-01-02"),
+			"first_air_date.lte":  time.Now().UTC().Format(time.DateOnly),
 			"with_origin_country": params.Country,
 		}
 	} else if params.Language != "" {
 		p = napping.Params{
 			"language":               language,
 			"sort_by":                "popularity.desc",
-			"first_air_date.lte":     time.Now().UTC().Format("2006-01-02"),
+			"first_air_date.lte":     time.Now().UTC().Format(time.DateOnly),
 			"with_original_language": params.Language,
 		}
 	} else {
 		p = napping.Params{
 			"language":           language,
 			"sort_by":            "popularity.desc",
-			"first_air_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"first_air_date.lte": time.Now().UTC().Format(time.DateOnly),
 		}
 	}
 
@@ -306,28 +306,28 @@ func RecentShows(params DiscoverFilters, language string, page int) (Shows, int)
 		p = napping.Params{
 			"language":           language,
 			"sort_by":            "first_air_date.desc",
-			"first_air_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"first_air_date.lte": time.Now().UTC().Format(time.DateOnly),
 			"with_genres":        params.Genre,
 		}
 	} else if params.Country != "" {
 		p = napping.Params{
 			"language":           language,
 			"sort_by":            "first_air_date.desc",
-			"first_air_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"first_air_date.lte": time.Now().UTC().Format(time.DateOnly),
 			"region":             params.Country,
 		}
 	} else if params.Language != "" {
 		p = napping.Params{
 			"language":               language,
 			"sort_by":                "first_air_date.desc",
-			"first_air_date.lte":     time.Now().UTC().Format("2006-01-02"),
+			"first_air_date.lte":     time.Now().UTC().Format(time.DateOnly),
 			"with_original_language": params.Language,
 		}
 	} else {
 		p = napping.Params{
 			"language":           language,
 			"sort_by":            "first_air_date.desc",
-			"first_air_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"first_air_date.lte": time.Now().UTC().Format(time.DateOnly),
 		}
 	}
 
@@ -341,29 +341,29 @@ func RecentEpisodes(params DiscoverFilters, language string, page int) (Shows, i
 	if params.Genre != "" {
 		p = napping.Params{
 			"language":           language,
-			"air_date.gte":       time.Now().UTC().AddDate(0, 0, -3).Format("2006-01-02"),
-			"first_air_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"air_date.gte":       time.Now().UTC().AddDate(0, 0, -3).Format(time.DateOnly),
+			"first_air_date.lte": time.Now().UTC().Format(time.DateOnly),
 			"with_genres":        params.Genre,
 		}
 	} else if params.Country != "" {
 		p = napping.Params{
 			"language":           language,
-			"air_date.gte":       time.Now().UTC().AddDate(0, 0, -3).Format("2006-01-02"),
-			"first_air_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"air_date.gte":       time.Now().UTC().AddDate(0, 0, -3).Format(time.DateOnly),
+			"first_air_date.lte": time.Now().UTC().Format(time.DateOnly),
 			"region":             params.Country,
 		}
 	} else if params.Language != "" {
 		p = napping.Params{
 			"language":               language,
-			"air_date.gte":           time.Now().UTC().AddDate(0, 0, -3).Format("2006-01-02"),
-			"first_air_date.lte":     time.Now().UTC().Format("2006-01-02"),
+			"air_date.gte":           time.Now().UTC().AddDate(0, 0, -3).Format(time.DateOnly),
+			"first_air_date.lte":     time.Now().UTC().Format(time.DateOnly),
 			"with_original_language": params.Language,
 		}
 	} else {
 		p = napping.Params{
 			"language":           language,
-			"air_date.gte":       time.Now().UTC().AddDate(0, 0, -3).Format("2006-01-02"),
-			"first_air_date.lte": time.Now().UTC().Format("2006-01-02"),
+			"air_date.gte":       time.Now().UTC().AddDate(0, 0, -3).Format(time.DateOnly),
+			"first_air_date.lte": time.Now().UTC().Format(time.DateOnly),
 		}
 	}
 
@@ -380,7 +380,7 @@ func MostVotedShows(genre string, language string, page int) (Shows, int) {
 	return listShows("discover/tv", "mostvoted", napping.Params{
 		"language":           language,
 		"sort_by":            "vote_count.desc",
-		"first_air_date.lte": time.Now().UTC().Format("2006-01-02"),
+		"first_air_date.lte": time.Now().UTC().Format(time.DateOnly),
 		"with_genres":        genre,
 	}, page)
 }

--- a/trakt/movies.go
+++ b/trakt/movies.go
@@ -513,7 +513,7 @@ func ListItemsMovies(user string, listID string, isUpdateNeeded bool) (movies []
 }
 
 // CalendarMovies ...
-func CalendarMovies(endPoint string, page string, cacheExpire time.Duration) (movies []*CalendarMovie, total int, err error) {
+func CalendarMovies(endPoint string, page string, cacheExpire time.Duration, isUpdateNeeded bool) (movies []*CalendarMovie, total int, err error) {
 	defer perf.ScopeTimer()()
 
 	resultsPerPage := config.Get().ResultsPerPage
@@ -536,8 +536,9 @@ func CalendarMovies(endPoint string, page string, cacheExpire time.Duration) (mo
 		Result:      &movies,
 		Description: "calendar movies",
 
-		Cache:       true,
-		CacheExpire: cacheExpire,
+		Cache:            true,
+		CacheExpire:      cacheExpire,
+		CacheForceExpire: isUpdateNeeded,
 	}
 
 	if err = req.Do(); err != nil {

--- a/trakt/movies.go
+++ b/trakt/movies.go
@@ -513,7 +513,7 @@ func ListItemsMovies(user string, listID string, isUpdateNeeded bool) (movies []
 }
 
 // CalendarMovies ...
-func CalendarMovies(endPoint string, page string) (movies []*CalendarMovie, total int, err error) {
+func CalendarMovies(endPoint string, page string, cacheExpire time.Duration) (movies []*CalendarMovie, total int, err error) {
 	defer perf.ScopeTimer()()
 
 	resultsPerPage := config.Get().ResultsPerPage
@@ -536,7 +536,8 @@ func CalendarMovies(endPoint string, page string) (movies []*CalendarMovie, tota
 		Result:      &movies,
 		Description: "calendar movies",
 
-		Cache: true,
+		Cache:       true,
+		CacheExpire: cacheExpire,
 	}
 
 	if err = req.Do(); err != nil {

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -550,7 +550,7 @@ func PreviousListItemsShows(listID string) (shows []*Shows, err error) {
 }
 
 // CalendarShows ...
-func CalendarShows(endPoint string, page string) (shows []*CalendarShow, total int, err error) {
+func CalendarShows(endPoint string, page string, cacheExpire time.Duration) (shows []*CalendarShow, total int, err error) {
 	defer perf.ScopeTimer()()
 
 	resultsPerPage := config.Get().ResultsPerPage
@@ -573,7 +573,8 @@ func CalendarShows(endPoint string, page string) (shows []*CalendarShow, total i
 		Result:      &shows,
 		Description: "calendar shows",
 
-		Cache: true,
+		Cache:       true,
+		CacheExpire: cacheExpire,
 	}
 
 	if err := req.Do(); err != nil {

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -550,7 +550,7 @@ func PreviousListItemsShows(listID string) (shows []*Shows, err error) {
 }
 
 // CalendarShows ...
-func CalendarShows(endPoint string, page string, cacheExpire time.Duration) (shows []*CalendarShow, total int, err error) {
+func CalendarShows(endPoint string, page string, cacheExpire time.Duration, isUpdateNeeded bool) (shows []*CalendarShow, total int, err error) {
 	defer perf.ScopeTimer()()
 
 	resultsPerPage := config.Get().ResultsPerPage
@@ -573,8 +573,9 @@ func CalendarShows(endPoint string, page string, cacheExpire time.Duration) (sho
 		Result:      &shows,
 		Description: "calendar shows",
 
-		Cache:       true,
-		CacheExpire: cacheExpire,
+		Cache:            true,
+		CacheExpire:      cacheExpire,
+		CacheForceExpire: isUpdateNeeded,
 	}
 
 	if err := req.Do(); err != nil {

--- a/util/reqapi/request.go
+++ b/util/reqapi/request.go
@@ -177,6 +177,7 @@ func (r *Request) Do() (err error) {
 		if err = r.CacheRead(); err == nil {
 			return err
 		}
+		log.Debug(err)
 		r.Stage("CacheRead")
 		r.cachePending = true
 	}

--- a/util/time.go
+++ b/util/time.go
@@ -35,14 +35,15 @@ func UTCBod() time.Time {
 	return time.Date(year, month, day, 0, 0, 0, 0, t.Location())
 }
 
-func AirDateWithExpireCheck(dt string, dateFormat string, allowSameDay bool) (time.Time, bool) {
-	aired, _ := time.Parse(dateFormat, dt)
+// AirDateWithAiredCheck returns the aired date and flag if it was already aired
+func AirDateWithAiredCheck(dt string, dateFormat string, allowSameDay bool) (airDate time.Time, isAired bool) {
+	airDate, _ = time.Parse(dateFormat, dt)
 	now := UTCBod()
-	if aired.After(now) || (!allowSameDay && aired.Equal(now)) {
-		return aired, true
+	if airDate.After(now) || (!allowSameDay && airDate.Equal(now)) {
+		return airDate, false
 	}
 
-	return aired, false
+	return airDate, true
 }
 
 func GetTimeFromFile(timeFile string) (time.Time, error) {


### PR DESCRIPTION
Improve Trakt calendars usability:

1. use time.DateOnly instead of hardcoded "2006-01-02"

2. use proper release date for movies dvd releases in calendar

3. Rename AirDateWithExpireCheck to AirDateWithAiredCheck 

AirDateWithExpireCheck function had a really strange name.
It returned "true" if air date is in the FUTURE, but then we used that value as variable called "isExpired" (== "isAired") which should mean that video was already aired (air date is in the PAST), but in `if` we check for future (e.g. inside of `if !config.Get().ShowUnairedEpisodes {`).
Maybe it supposed to be "isNotExpired" (== "isNotAired"), but was left as is.
Anyway, this is extremely confusing.

So I decided to change it to AirDateWithAiredCheck and change returning values. So then we use its result as isAired which is straightforward.

4. Rename TraktProgressUnaired to TraktProgressHideUnaired to make it self-explanatory.

5. Hide watched and "expired" (if cache is long) videos in calendars. Fixes https://github.com/elgatito/plugin.video.elementum/issues/982

6. Set explicit cache expiration for calendars. For "my" - "1 hour", since user can add new show and will expect calendar to be updated. For "all" - "1 day". "1 day" because as it was changed to "1 day" in https://github.com/elgatito/elementum/commit/20ae2531ff2b21bf12e5ca90ce12205f9ca47c6d), but maybe we can use "7 days" as it was before that change. This calendar is not connected to user, so probably it is more static.