### PR TITLE
Use /lists/ only for Official lists to avoid server side caching.

### DIFF
--- a/cache/types.go
+++ b/cache/types.go
@@ -74,7 +74,7 @@ const (
 	TraktMoviesCollectionKey               = TraktKey + "movies.collection"
 	TraktMoviesCollectionExpire            = CacheExpireLong
 	TraktMoviesListKey                     = TraktKey + "movies.list.%s"
-	TraktMoviesListExpire                  = CacheExpireLong
+	TraktMoviesListExpire                  = CacheExpireExtra
 	TraktMoviesCalendarKey                 = TraktKey + "movies.calendar.%s.%s.%d"
 	TraktMoviesCalendarAllExpire           = CacheExpireLong
 	TraktMoviesCalendarMyExpire            = CacheExpireShort
@@ -99,7 +99,7 @@ const (
 	TraktShowsCollectionKey                = TraktKey + "shows.collection"
 	TraktShowsCollectionExpire             = CacheExpireLong
 	TraktShowsListKey                      = TraktKey + "shows.list.%s"
-	TraktShowsListExpire                   = CacheExpireLong
+	TraktShowsListExpire                   = CacheExpireExtra
 	TraktShowsCalendarKey                  = TraktKey + "shows.calendar.%s.%s.%d"
 	TraktShowsCalendarAllExpire            = CacheExpireExtra
 	TraktShowsCalendarMyExpire             = CacheExpireLong

--- a/trakt/lists.go
+++ b/trakt/lists.go
@@ -45,9 +45,9 @@ func (l *List) ID() int {
 func GetList(user, listID string) (list *List, err error) {
 	defer perf.ScopeTimer()()
 
-	url := fmt.Sprintf("/lists/%s", listID)
-	if user == "" || user == config.Get().TraktUsername {
-		url = fmt.Sprintf("users/%s/lists/%s", config.Get().TraktUsername, listID)
+	url := fmt.Sprintf("users/%s/lists/%s", user, listID)
+	if user == "Trakt" { // if this is "Official" public list - we use special endpoint
+		url = fmt.Sprintf("/lists/%s", listID)
 	}
 
 	req := &reqapi.Request{

--- a/trakt/movies.go
+++ b/trakt/movies.go
@@ -419,9 +419,9 @@ func ListItemsMovies(user, listID string) (movies []*Movies, err error) {
 	listActivities, err := GetListActivities(user, listID)
 	isUpdateNeeded := err != nil || listActivities.IsUpdated()
 
-	url := fmt.Sprintf("/lists/%s/items/movies", listID)
-	if user == "" || user == config.Get().TraktUsername {
-		url = fmt.Sprintf("users/%s/lists/%s/items/movies", config.Get().TraktUsername, listID)
+	url := fmt.Sprintf("users/%s/lists/%s/items/movies", user, listID)
+	if user == "Trakt" { // if this is "Official" public list - we use special endpoint
+		url = fmt.Sprintf("/lists/%s/items/movies", listID)
 	}
 
 	cacheStore := cache.NewDBStore()

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -440,9 +440,9 @@ func ListItemsShows(user, listID string) (shows []*Shows, err error) {
 	listActivities, err := GetListActivities(user, listID)
 	isUpdateNeeded := err != nil || listActivities.IsUpdated()
 
-	url := fmt.Sprintf("/lists/%s/items/shows", listID)
-	if user == "" || user == config.Get().TraktUsername {
-		url = fmt.Sprintf("users/%s/lists/%s/items/shows", config.Get().TraktUsername, listID)
+	url := fmt.Sprintf("users/%s/lists/%s/items/shows", user, listID)
+	if user == "Trakt" { // if this is "Official" public list - we use special endpoint
+		url = fmt.Sprintf("/lists/%s/items/shows", listID)
 	}
 
 	cacheStore := cache.NewDBStore()


### PR DESCRIPTION
Use /lists/ only for Official lists to avoid server side caching.

Also increase caching time for lists since now we rely on user activities.

Example of official list:
```
$ curl -s -H @trakt-headers.txt https://api.trakt.tv/lists/41 | jq
...
  "user": {
    "username": "Trakt",
    "private": false,
    "name": null,
    "vip": false,
    "vip_ep": false,
    "ids": {
      "slug": null
    }
  }
```

Fixes https://github.com/elgatito/plugin.video.elementum/issues/711