### PR TITLE
For Trakt lists - also compare air time, not only date

### DIFF
--- a/util/time.go
+++ b/util/time.go
@@ -39,6 +39,11 @@ func UTCBod() time.Time {
 func AirDateWithAiredCheck(dt string, dateFormat string, allowSameDay bool) (airDate time.Time, isAired bool) {
 	airDate, _ = time.Parse(dateFormat, dt)
 	now := UTCBod()
+	//if we got date with time - we also should compare air time with our time
+	if dateFormat != time.DateOnly {
+		now = time.Now().UTC()
+	}
+
 	if airDate.After(now) || (!allowSameDay && airDate.Equal(now)) {
 		return airDate, false
 	}


### PR DESCRIPTION
if we got date with time - we also should compare air time with our time.

иногда у trakt и themoviedb данные разные о выходе эпизода (у тракта раньше, например), но мы в любом случае игнорируем время пользователя, поэтому эпизод будет виден только на следующий день у любого источника.

можно по другому реализовать, но закомиченный вариант покажет эпизод как раз после того как он вышел, мне так кажется правильным. для tmdb понятно что у нас есть проверка на equal() if sameday так как там нету времени, а для тракта хватит только after().

тесты https://go.dev/play/p/FA8OYs2XmaK

альтернативные реализации:
```
//if we got date with time - we also should compare air time with our time
//we can also check if allowSameDay is  set, but this allowSameDay only makes sense for TMDB,
// where we do not have time of air
if dateFormat != time.DateOnly && allowSameDay {
	now = time.Now().UTC()
}
```
```
//alternative version of check
if airDate.Hour() != 0 && airDate.Minute() != 0 && airDate.Second() != 0 && airDate.Nanosecond() != 0 {
	now = time.Now().UTC()
}
```
```
// или можно деградировать данные и убрать точность, убрав время,
// будет как у TMDB, тогда не надо менять логику, но теряем точность
airDate = Bod(airDate)
```
пример
https://trakt.tv/shows/metallic-rouge/seasons/1/episodes/8
February 28, 2024 19:00
https://www.themoviedb.org/tv/222787-metallic-rouge/season/1/episode/8
29 February 2024