### PR TITLE
AssignTorrent: try to find torrent in torrents history first

### DIFF
--- a/database/storm.go
+++ b/database/storm.go
@@ -245,7 +245,7 @@ func (d *StormDatabase) AddTorrentLink(tmdbID, infoHash string, b []byte, force 
 			InfoHash: infoHash,
 			Metadata: b,
 		}
-		// we could use just Save() since TorrentAssignMetadata does not have unique field, but bettert to be explicit
+		// we could use just Save() since TorrentAssignMetadata does not have unique field, but better to be explicit
 		if err == nil {
 			d.db.Update(&tm)
 		} else {


### PR DESCRIPTION
so, as far as i remember, when i developed this feature i tested both locations: "torrents history" and "active torrents list", and i decided to use  "torrents history" as default since it usually has more torrents.

but now i realize that most likely i used a torrent that was in both "torrents history" and "active torrents list".
and the issue is that i used GetTorrentFromParam that uses GetTorrentByHash that does FindByHash for **Queue**, so if torrent is not in the queue - it can not find torrent.

now i changed the code to search in history first and then in queue.
so assigning will work for both locations now.

fixes https://github.com/elgatito/context.elementum/issues/28

