### PR TITLE
Trakt: "Use earliest release date for progress and calendars" option

### DIFF
--- a/api/trakt.go
+++ b/api/trakt.go
@@ -1386,17 +1386,7 @@ func renderCalendarShows(ctx *gin.Context, shows []*trakt.CalendarShow, total in
 				episode = tmdb.GetEpisode(showListing.Show.IDs.TMDB, epi.Season, epi.Number, language)
 
 				if episode != nil {
-					if config.Get().TraktUseLowestReleaseDate {
-						traktAirDate, err1 := time.Parse(time.RFC3339, airDate)
-						tmdbAirDate, err2 := time.Parse(time.DateOnly, episode.AirDate)
-						if err1 == nil && err2 == nil && tmdbAirDate.Before(traktAirDate) {
-							airDate = episode.AirDate
-							airDateFormat = time.DateOnly
-						}
-					} else {
-						airDate = episode.AirDate
-						airDateFormat = time.DateOnly
-					}
+					airDate, airDateFormat = episode.GetLowestAirDate(airDate, airDateFormat)
 
 					seasonNumber = episode.SeasonNumber
 					episodeNumber = episode.EpisodeNumber
@@ -1569,17 +1559,7 @@ func renderProgressShows(ctx *gin.Context, shows []*trakt.ProgressShow, total in
 				}
 
 				if episode != nil {
-					if config.Get().TraktUseLowestReleaseDate {
-						traktAirDate, err1 := time.Parse(time.RFC3339, airDate)
-						tmdbAirDate, err2 := time.Parse(time.DateOnly, episode.AirDate)
-						if err1 == nil && err2 == nil && tmdbAirDate.Before(traktAirDate) {
-							airDate = episode.AirDate
-							airDateFormat = time.DateOnly
-						}
-					} else {
-						airDate = episode.AirDate
-						airDateFormat = time.DateOnly
-					}
+					airDate, airDateFormat = episode.GetLowestAirDate(airDate, airDateFormat)
 
 					seasonNumber = episode.SeasonNumber
 					episodeNumber = episode.EpisodeNumber

--- a/config/config.go
+++ b/config/config.go
@@ -90,7 +90,6 @@ type Configuration struct {
 	ChooseStreamAutoSearch      bool
 	ForceLinkType               bool
 	UseOriginalTitle            bool
-	TraktUseLowestReleaseDate   bool
 	AddSpecials                 bool
 	AddEpisodeNumbers           bool
 	ShowUnairedSeasons          bool
@@ -209,6 +208,7 @@ type Configuration struct {
 	TraktCalendarsColorShow        string
 	TraktCalendarsColorEpisode     string
 	TraktCalendarsColorUnaired     string
+	TraktUseLowestReleaseDate      bool
 
 	UpdateFrequency                int
 	UpdateDelay                    int
@@ -597,7 +597,6 @@ func Reload() (ret *Configuration, err error) {
 		ChooseStreamAutoSearch:      settings.ToBool("choose_stream_auto_search"),
 		ForceLinkType:               settings.ToBool("force_link_type"),
 		UseOriginalTitle:            settings.ToBool("use_original_title"),
-		TraktUseLowestReleaseDate:   settings.ToBool("trakt_use_lowest_release_date"),
 		AddSpecials:                 settings.ToBool("add_specials"),
 		AddEpisodeNumbers:           settings.ToBool("add_episode_numbers"),
 		ShowUnairedSeasons:          settings.ToBool("unaired_seasons"),
@@ -693,6 +692,7 @@ func Reload() (ret *Configuration, err error) {
 		TraktCalendarsColorShow:        settings.ToString("trakt_calendars_color_show"),
 		TraktCalendarsColorEpisode:     settings.ToString("trakt_calendars_color_episode"),
 		TraktCalendarsColorUnaired:     settings.ToString("trakt_calendars_color_unaired"),
+		TraktUseLowestReleaseDate:      settings.ToBool("trakt_use_lowest_release_date"),
 
 		UpdateFrequency:                settings.ToInt("library_update_frequency"),
 		UpdateDelay:                    settings.ToInt("library_update_delay"),

--- a/config/config.go
+++ b/config/config.go
@@ -90,7 +90,7 @@ type Configuration struct {
 	ChooseStreamAutoSearch      bool
 	ForceLinkType               bool
 	UseOriginalTitle            bool
-	UseLowestReleaseDate        bool
+	TraktUseLowestReleaseDate   bool
 	AddSpecials                 bool
 	AddEpisodeNumbers           bool
 	ShowUnairedSeasons          bool
@@ -237,6 +237,7 @@ type Configuration struct {
 
 	CustomProviderTimeoutEnabled bool
 	CustomProviderTimeout        int
+	ProviderUseLowestReleaseDate bool
 
 	InternalDNSEnabled  bool
 	InternalDNSSkipIPv6 bool
@@ -596,7 +597,7 @@ func Reload() (ret *Configuration, err error) {
 		ChooseStreamAutoSearch:      settings.ToBool("choose_stream_auto_search"),
 		ForceLinkType:               settings.ToBool("force_link_type"),
 		UseOriginalTitle:            settings.ToBool("use_original_title"),
-		UseLowestReleaseDate:        settings.ToBool("use_lowest_release_date"),
+		TraktUseLowestReleaseDate:   settings.ToBool("trakt_use_lowest_release_date"),
 		AddSpecials:                 settings.ToBool("add_specials"),
 		AddEpisodeNumbers:           settings.ToBool("add_episode_numbers"),
 		ShowUnairedSeasons:          settings.ToBool("unaired_seasons"),
@@ -720,6 +721,7 @@ func Reload() (ret *Configuration, err error) {
 
 		CustomProviderTimeoutEnabled: settings.ToBool("custom_provider_timeout_enabled"),
 		CustomProviderTimeout:        settings.ToInt("custom_provider_timeout"),
+		ProviderUseLowestReleaseDate: settings.ToBool("provider_use_lowest_release_date"),
 
 		InternalDNSEnabled:  settings.ToBool("internal_dns_enabled"),
 		InternalDNSSkipIPv6: settings.ToBool("internal_dns_skip_ipv6"),

--- a/providers/xbmc.go
+++ b/providers/xbmc.go
@@ -168,7 +168,7 @@ func (as *AddonSearcher) GetMovieSearchObject(movie *tmdb.Movie) *MovieSearchObj
 	title := movie.OriginalTitle
 
 	// Iterate through all available dates and take the earliest one as a basic date for searching
-	if config.Get().UseLowestReleaseDate && movie.ReleaseDates != nil && movie.ReleaseDates.Results != nil {
+	if config.Get().ProviderUseLowestReleaseDate && movie.ReleaseDates != nil && movie.ReleaseDates.Results != nil {
 		for _, r := range movie.ReleaseDates.Results {
 			if r.ReleaseDates == nil {
 				continue

--- a/tmdb/episode.go
+++ b/tmdb/episode.go
@@ -241,3 +241,19 @@ func (episode *Episode) findTranslation(language string) *Translation {
 
 	return nil
 }
+
+func (episode *Episode) GetLowestAirDate(airDate string, airDateFormat string) (newAirDate string, newAirDateFormat string) {
+	newAirDate = episode.AirDate
+	newAirDateFormat = time.DateOnly
+
+	if config.Get().TraktUseLowestReleaseDate {
+		airDateParsed, err1 := time.Parse(airDateFormat, airDate)
+		tmdbAirDateParsed, err2 := time.Parse(time.DateOnly, episode.AirDate)
+		if err1 == nil && err2 == nil && airDateParsed.Before(tmdbAirDateParsed) {
+			newAirDate = airDate
+			newAirDateFormat = airDateFormat
+		}
+	}
+
+	return
+}

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -114,7 +114,7 @@ func GetSeasonEpisodes(showID, seasonNumber int) (episodes []*Episode) {
 		API:         reqapi.TraktAPI,
 		URL:         fmt.Sprintf("shows/%d/seasons/%d", showID, seasonNumber),
 		Header:      GetAvailableHeader(),
-		Params:      napping.Params{"extended": "episodes,full"}.AsUrlValues(),
+		Params:      napping.Params{"extended": "full"}.AsUrlValues(),
 		Result:      &episodes,
 		Description: "show season episodes",
 
@@ -619,6 +619,7 @@ func WatchedShowsProgress() (shows []*ProgressShow, err error) {
 		"hidden":         "false",
 		"specials":       "false",
 		"count_specials": "false",
+		"extended":       "full",
 	}.AsUrlValues()
 
 	showsList := make([]*ProgressShow, len(watchedShows))


### PR DESCRIPTION
So if user use TMDB as data source (default) - user still can get more precise air date from Trakt.

Also:
Fixes WatchedShowsProgress not getting episodes ,thus in renderProgressShows we had empty epi.FirstAired and we had to call trakt.GetSeasonEpisodes. Now it should be faster.
GetSeasonEpisodes does not have extended=episodes, only extended=full.
Rename UseLowestReleaseDate to ProvideUseLowestReleaseDate to avoid confusion.


depends on https://github.com/elgatito/plugin.video.elementum/pull/1007