### PR TITLE
renderCalendarShows displays episodes, not tvshows.

### DIFF
--- a/api/trakt.go
+++ b/api/trakt.go
@@ -1495,7 +1495,7 @@ func renderCalendarShows(ctx *gin.Context, shows []*trakt.CalendarShow, total in
 		}
 		items = append(items, nextpage)
 	}
-	ctx.JSON(200, xbmc.NewView("tvshows", items))
+	ctx.JSON(200, xbmc.NewView("episodes", items))
 }
 
 func renderProgressShows(ctx *gin.Context, shows []*trakt.ProgressShow, total int, page int) {


### PR DESCRIPTION
renderCalendarShows displays episodes, not tvshows.

so it will be the same as renderProgressShows (which also displays episodes).