### PR TITLE
Ignore "none" color in item label. Fix missing text on episodes view with Estuary skin.

### DIFF
--- a/api/trakt.go
+++ b/api/trakt.go
@@ -1169,7 +1169,7 @@ func renderCalendarMovies(ctx *gin.Context, movies []*trakt.CalendarMovie, total
 	}
 
 	colorDate := config.Get().TraktCalendarsColorDate
-	colorShow := config.Get().TraktCalendarsColorShow
+	colorMovie := config.Get().TraktCalendarsColorShow
 	dateFormat := getCalendarsDateFormat()
 
 	now := util.UTCBod()
@@ -1212,8 +1212,12 @@ func renderCalendarMovies(ctx *gin.Context, movies []*trakt.CalendarMovie, total
 				return
 			}
 
-			label := fmt.Sprintf(`[COLOR %s]%s[/COLOR] | [B][COLOR %s]%s[/COLOR][/B] `,
-				colorDate, aired.Format(dateFormat), colorShow, item.Label)
+			movieName := item.Label
+			if colorMovie != "none" {
+				movieName = fmt.Sprintf(`[COLOR %s]%s[/COLOR]`, colorMovie, movieName)
+			}
+			label := fmt.Sprintf(`[COLOR %s]%s[/COLOR] | [B]%s[/B]`,
+				colorDate, aired.Format(dateFormat), movieName)
 			item.Label = label
 			item.Info.Title = label
 
@@ -1421,8 +1425,11 @@ func renderCalendarShows(ctx *gin.Context, shows []*trakt.CalendarShow, total in
 			item.Info.Premiered = airDate
 			item.Info.LastPlayed = airDate
 
-			episodeLabel := fmt.Sprintf(`[COLOR %s]%s[/COLOR] | [B][COLOR %s]%s[/COLOR][/B] - [I][COLOR %s]%dx%02d %s[/COLOR][/I]`,
-				colorDate, aired.Format(dateFormat), colorShow, showName, localEpisodeColor, seasonNumber, episodeNumber, episodeName)
+			if colorShow != "none" {
+				showName = fmt.Sprintf(`[COLOR %s]%s[/COLOR]`, colorShow, showName)
+			}
+			episodeLabel := fmt.Sprintf(`[COLOR %s]%s[/COLOR] | [B]%s[/B] - [I][COLOR %s]%dx%02d %s[/COLOR][/I]`,
+				colorDate, aired.Format(dateFormat), showName, localEpisodeColor, seasonNumber, episodeNumber, episodeName)
 			item.Label = episodeLabel
 			item.Info.Title = episodeLabel
 
@@ -1589,8 +1596,11 @@ func renderProgressShows(ctx *gin.Context, shows []*trakt.ProgressShow, total in
 			item.Info.Premiered = airDate
 			item.Info.LastPlayed = airDate
 
-			episodeLabel := fmt.Sprintf(`[COLOR %s]%s[/COLOR] | [B][COLOR %s]%s[/COLOR][/B] - [I][COLOR %s]%dx%02d %s[/COLOR][/I]`,
-				colorDate, aired.Format(dateFormat), colorShow, showName, localEpisodeColor, seasonNumber, episodeNumber, episodeName)
+			if colorShow != "none" {
+				showName = fmt.Sprintf(`[COLOR %s]%s[/COLOR]`, colorShow, showName)
+			}
+			episodeLabel := fmt.Sprintf(`[COLOR %s]%s[/COLOR] | [B]%s[/B] - [I][COLOR %s]%dx%02d %s[/COLOR][/I]`,
+				colorDate, aired.Format(dateFormat), showName, localEpisodeColor, seasonNumber, episodeNumber, episodeName)
 			item.Label = episodeLabel
 			item.Info.Title = episodeLabel
 


### PR DESCRIPTION
with default skin Estuary on episodes view we have no text because of `color none`:
![progress with none color on estuary skin](https://github.com/elgatito/plugin.video.elementum/assets/17964763/0111bbc8-b121-4d92-bf89-c9b3889e1881)

after change:
![new progress with none color on estuary skin](https://github.com/elgatito/elementum/assets/17964763/1204f785-c45a-4aa4-bf02-9cd107d2e562)


alternative implementation of https://github.com/elgatito/plugin.video.elementum/pull/1011