### PR TITLE
Make reqapi use internal dns/proxy if enabled

### DIFF
--- a/proxy/client.go
+++ b/proxy/client.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,7 +21,7 @@ var (
 	}
 
 	// InternalProxyURL holds parsed internal proxy url
-	internalProxyURL, _ = url.Parse("http://127.0.0.1:65222")
+	internalProxyURL, _ = url.Parse("http://127.0.0.1:" + strconv.Itoa(ProxyPort))
 
 	directTransport = &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -28,7 +28,10 @@ var (
 	}
 	directClient = &http.Client{
 		Transport: directTransport,
-		Timeout:   15 * time.Second,
+		// TODO: with 15 i get timeouts for many Trakt and TMDB,
+		// with 60 i get timeouts for long calls.
+		// reqapi client did not have a timeout, so maybe this client also should not have it?
+		Timeout: 120 * time.Second,
 	}
 
 	proxyTransport = &http.Transport{
@@ -37,7 +40,7 @@ var (
 	}
 	proxyClient = &http.Client{
 		Transport: proxyTransport,
-		Timeout:   30 * time.Second,
+		Timeout:   120 * time.Second,
 	}
 )
 
@@ -49,7 +52,7 @@ func Reload() {
 		directTransport.Proxy = nil
 	} else {
 		proxyURL, _ := url.Parse(config.Get().ProxyURL)
-		directTransport.Proxy = GetProxyURL(proxyURL)
+		directTransport.Proxy = http.ProxyURL(proxyURL)
 
 		log.Debugf("Setting up proxy for direct client: %s", config.Get().ProxyURL)
 	}
@@ -78,7 +81,9 @@ func CustomDial(network, addr string) (net.Conn, error) {
 	addrs := strings.Split(addr, ":")
 	if len(addrs) == 2 && len(addrs[0]) > 2 && strings.Contains(addrs[0], ".") {
 		if ipTest := net.ParseIP(addrs[0]); ipTest == nil {
+			log.Debugf("Resolving %s", addrs[0])
 			if ips, err := resolve(addrs[0]); err == nil && len(ips) > 0 {
+				log.Debugf("Resolved %s to %s", addrs[0], ips)
 				for _, i := range ips {
 					if config.Get().InternalDNSSkipIPv6 {
 						if ip := net.ParseIP(i); ip == nil || ip.To4() == nil {
@@ -90,6 +95,8 @@ func CustomDial(network, addr string) (net.Conn, error) {
 						return c, err
 					}
 				}
+			} else {
+				log.Debugf("Failed to resolve %s: %s", addrs[0], err)
 			}
 		}
 	}
@@ -106,27 +113,26 @@ func CustomDialContext(ctx context.Context, network, addr string) (net.Conn, err
 	addrs := strings.Split(addr, ":")
 	if len(addrs) == 2 && len(addrs[0]) > 2 && strings.Contains(addrs[0], ".") {
 		if ipTest := net.ParseIP(addrs[0]); ipTest == nil {
-			if ip, err := resolve(addrs[0]); err == nil && len(ip) > 0 {
-				if !config.Get().InternalDNSSkipIPv6 {
-					addr = ip[0] + ":" + addrs[1]
-				} else {
-					for _, i := range ip {
-						if len(i) == net.IPv4len {
-							addr = i + ":" + addrs[1]
-							break
+			// NOTE: these changes were ported from CustomDial and they works.
+			log.Debugf("Resolving %s", addrs[0])
+			if ips, err := resolve(addrs[0]); err == nil && len(ips) > 0 {
+				log.Debugf("Resolved %s to %s", addrs[0], ips)
+				for _, i := range ips {
+					if config.Get().InternalDNSSkipIPv6 {
+						if ip := net.ParseIP(i); ip == nil || ip.To4() == nil {
+							continue
 						}
 					}
+
+					if c, err := dialer.Dial(network, i+":"+addrs[1]); err == nil {
+						return c, err
+					}
 				}
+			} else {
+				log.Debugf("Failed to resolved %s: %s", addrs[0], err)
 			}
 		}
 	}
 
 	return dialer.DialContext(ctx, network, addr)
-}
-
-// GetProxyURL ...
-func GetProxyURL(fixedURL *url.URL) func(*http.Request) (*url.URL, error) {
-	return func(r *http.Request) (*url.URL, error) {
-		return fixedURL, nil
-	}
 }

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -29,10 +29,6 @@ var (
 	}
 	directClient = &http.Client{
 		Transport: directTransport,
-		// TODO: with 15 i get timeouts for many Trakt and TMDB,
-		// with 60 i get timeouts for long calls.
-		// reqapi client did not have a timeout, so maybe this client also should not have it?
-		Timeout: 120 * time.Second,
 	}
 
 	proxyTransport = &http.Transport{
@@ -41,7 +37,6 @@ var (
 	}
 	proxyClient = &http.Client{
 		Transport: proxyTransport,
-		Timeout:   120 * time.Second,
 	}
 )
 

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -77,7 +77,6 @@ func CustomDial(network, addr string) (net.Conn, error) {
 	addrs := strings.Split(addr, ":")
 	if len(addrs) == 2 && len(addrs[0]) > 2 && strings.Contains(addrs[0], ".") {
 		if ipTest := net.ParseIP(addrs[0]); ipTest == nil {
-			log.Debugf("Resolving %s", addrs[0])
 			if ips, err := resolve(addrs[0]); err == nil && len(ips) > 0 {
 				log.Debugf("Resolved %s to %s", addrs[0], ips)
 				for _, i := range ips {
@@ -92,7 +91,7 @@ func CustomDial(network, addr string) (net.Conn, error) {
 					}
 				}
 			} else {
-				log.Debugf("Failed to resolve %s: %s", addrs[0], err)
+				log.Errorf("Failed to resolve %s: %s", addrs[0], err)
 			}
 		}
 	}
@@ -109,8 +108,6 @@ func CustomDialContext(ctx context.Context, network, addr string) (net.Conn, err
 	addrs := strings.Split(addr, ":")
 	if len(addrs) == 2 && len(addrs[0]) > 2 && strings.Contains(addrs[0], ".") {
 		if ipTest := net.ParseIP(addrs[0]); ipTest == nil {
-			// NOTE: these changes were ported from CustomDial and they works.
-			log.Debugf("Resolving %s", addrs[0])
 			if ips, err := resolve(addrs[0]); err == nil && len(ips) > 0 {
 				log.Debugf("Resolved %s to %s", addrs[0], ips)
 				for _, i := range ips {
@@ -120,12 +117,12 @@ func CustomDialContext(ctx context.Context, network, addr string) (net.Conn, err
 						}
 					}
 
-					if c, err := dialer.Dial(network, i+":"+addrs[1]); err == nil {
+					if c, err := dialer.DialContext(ctx, network, i+":"+addrs[1]); err == nil {
 						return c, err
 					}
 				}
 			} else {
-				log.Debugf("Failed to resolved %s: %s", addrs[0], err)
+				log.Errorf("Failed to resolve %s: %s", addrs[0], err)
 			}
 		}
 	}

--- a/proxy/dns.go
+++ b/proxy/dns.go
@@ -62,15 +62,11 @@ func init() {
 func getProvidersOrdered(conf int) []int {
 	switch conf {
 	case 1:
-		return []int{doh.GoogleProvider, doh.CloudflareProvider, doh.Quad9Provider}
-	case 2:
-		return []int{doh.CloudflareProvider, doh.Quad9Provider, doh.GoogleProvider}
-	case 3:
 		// To unblock TMDB we should use only Quad9, b/c if we specify multiple providers
 		// then doh package "will try to select the fastest"
 		return []int{doh.Quad9Provider}
 	default:
-		return []int{doh.Quad9Provider, doh.GoogleProvider, doh.CloudflareProvider}
+		return []int{doh.GoogleProvider, doh.CloudflareProvider, doh.Quad9Provider}
 	}
 }
 
@@ -112,8 +108,6 @@ func resolve(addr string) ([]string, error) {
 
 	commonLock.RLock()
 	defer commonLock.RUnlock()
-
-	doh.Use()
 
 	resp, err := commonResolver.Query(context.TODO(), dns.Domain(addr), dns.TypeA)
 	if err == nil && resp != nil && resp.Answer != nil {

--- a/proxy/dns.go
+++ b/proxy/dns.go
@@ -65,6 +65,10 @@ func getProvidersOrdered(conf int) []int {
 		return []int{doh.GoogleProvider, doh.CloudflareProvider, doh.Quad9Provider}
 	case 2:
 		return []int{doh.CloudflareProvider, doh.Quad9Provider, doh.GoogleProvider}
+	case 3:
+		// To unblock TMDB we should use only Quad9, b/c if we specify multiple providers
+		// then doh package "will try to select the fastest"
+		return []int{doh.Quad9Provider}
 	default:
 		return []int{doh.Quad9Provider, doh.GoogleProvider, doh.CloudflareProvider}
 	}
@@ -108,6 +112,8 @@ func resolve(addr string) ([]string, error) {
 
 	commonLock.RLock()
 	defer commonLock.RUnlock()
+
+	doh.Use()
 
 	resp, err := commonResolver.Query(context.TODO(), dns.Domain(addr), dns.TypeA)
 	if err == nil && resp != nil && resp.Answer != nil {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -139,10 +139,10 @@ func StartProxy() *CustomProxy {
 
 	if config.Get().ProxyURL != "" {
 		proxyURL, _ := url.Parse(config.Get().ProxyURL)
-		Proxy.Tr.Proxy = GetProxyURL(proxyURL)
+		Proxy.Tr.Proxy = http.ProxyURL(proxyURL)
 		log.Debugf("Setting up proxy for internal proxy: %s", config.Get().ProxyURL)
 	} else {
-		Proxy.Tr.Proxy = GetProxyURL(nil)
+		Proxy.Tr.Proxy = http.ProxyURL(nil)
 	}
 
 	if config.Get().InternalDNSEnabled {

--- a/util/ip/ip.go
+++ b/util/ip/ip.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/elgatito/elementum/config"
+	"github.com/elgatito/elementum/proxy"
 
 	"github.com/gin-gonic/gin"
 	"github.com/op/go-logging"
@@ -247,7 +248,7 @@ func InternalProxyURL() string {
 		ip = localIP.String()
 	}
 
-	return "http://" + ip + ":65222"
+	return "http://" + ip + ":" + strconv.Itoa(proxy.ProxyPort)
 }
 
 func RequestUserIP(r *http.Request) string {

--- a/util/reqapi/api.go
+++ b/util/reqapi/api.go
@@ -2,12 +2,10 @@ package reqapi
 
 import (
 	"fmt"
-	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
-	"github.com/elgatito/elementum/config"
+	"github.com/elgatito/elementum/proxy"
 	"github.com/elgatito/elementum/util"
 
 	"github.com/jmcvetta/napping"
@@ -76,16 +74,7 @@ func (api *API) GetURL(url string) string {
 }
 
 func (api *API) GetSession() *napping.Session {
-	httpTransport := &http.Transport{}
-	if config.Get().ProxyURL != "" {
-		proxyURL, _ := url.Parse(config.Get().ProxyURL)
-		httpTransport.Proxy = http.ProxyURL(proxyURL)
-	}
-	httpClient := &http.Client{
-		Transport: httpTransport,
-	}
-
 	return &napping.Session{
-		Client: httpClient,
+		Client: proxy.GetClient(),
 	}
 }


### PR DESCRIPTION
I noticed that reqapi does not use internal dns/proxy. Other requests are using dns/proxy, like requests to providers or to opensubtitles.

---
@elgatito нужны советы по некоторым пунктам:

1. Если "internal proxy + dns", то используется CustomDial, он рабочий в плане dns, но если "internal dns only" то используется CustomDialContext, он был не исправлен в плане днс, но я взял код из CustomDial и всё стало ок.
2. в reqapi не было timeout, в proxy они есть, но у меня старые значения всегда вызывали отвал trakt/tmdb запросов. может уберём timeout или сделаем их большими? в коде есть комменты.
3.  To unblock TMDB we should use only Quad9, b/c if we specify multiple providers then doh package "will try to select the fastest" - сначала я это заметил во время тестов, а потом глянул их документацию и код. Если нет возражений то добавлю в настройки плагина доп выбор ("только Quad9").
4. вообще по факту опция `internal_dns_order` не сильно полезна так как в итоге он всё равно отсылает запрос на все сервера и берёт ответ от "быстрейшего" сервера.
5. заменил GetProxyURL на http.ProxyURL (оказалось что GetProxyURL это копия кода http.ProxyURL)
6. https://github.com/elgatito/elementum/blob/e4fb8271682bab752482b677761a164d6921314b/proxy/client.go#L23 // TODO: use `ip.InternalProxyURL()` but somehow avoid circular dependency
https://github.com/elgatito/elementum/blob/9b3202536f62970744cf79fab02890e40612d14e/util/ip/ip.go#L250 // TODO: use `proxy.ProxyPort` but somehow avoid circular dependency
может перенести InternalProxyURL из `ip` в `proxy`?

спасибо.