### PR TITLE
Check result for nil in resolver.Query()

### DIFF
--- a/proxy/dns.go
+++ b/proxy/dns.go
@@ -55,6 +55,12 @@ var (
 	dnsRunLocks     sync.Map
 )
 
+// Supported dns response types
+var (
+	ResponseTypeA    = 1
+	ResponseTypeAAAA = 28
+)
+
 func init() {
 	reloadDNS()
 }
@@ -75,7 +81,7 @@ func reloadDNS() {
 }
 
 // Each request is going through this workflow:
-// Check cache -> Query Opennic (is address belongs to Opennic domains) -> Query DoH providers -> Save cache
+// Check cache -> Query Opennic (if address belongs to Opennic domains) -> Query DoH providers -> Save cache
 func resolveAddr(addr string) (ret []string, err error) {
 	defer perf.ScopeTimer()()
 

--- a/proxy/resolver.go
+++ b/proxy/resolver.go
@@ -165,6 +165,9 @@ func IPs(resp *dns.Response) []string {
 	if resp != nil && resp.Answer != nil {
 		ips := make([]string, 0, len(resp.Answer))
 		for _, a := range resp.Answer {
+			if a.Type != ResponseTypeA && a.Type != ResponseTypeAAAA {
+				continue
+			}
 			ips = append(ips, a.Data)
 		}
 		return ips

--- a/proxy/resolver.go
+++ b/proxy/resolver.go
@@ -154,7 +154,7 @@ func (c *DoH) Query(ctx context.Context, d dns.Domain, t dns.Type, s ...dns.ECS)
 
 	result = <-r
 
-	if result.Status == -1 {
+	if result == nil || result.Status == -1 {
 		return nil, fmt.Errorf("doh: all query failed")
 	}
 

--- a/util/ip/ip.go
+++ b/util/ip/ip.go
@@ -248,7 +248,7 @@ func InternalProxyURL() string {
 		ip = localIP.String()
 	}
 
-	return "http://" + ip + ":" + strconv.Itoa(proxy.ProxyPort)
+	return fmt.Sprintf("http://%s:%d", ip, proxy.ProxyPort)
 }
 
 func RequestUserIP(r *http.Request) string {


### PR DESCRIPTION
иначе если все провайдеры отдали 127.0.0.1 у нас result == nil и паника на `result.Status == -1`

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xb9682f]

goroutine 89 [running]:
github.com/elgatito/elementum/proxy.(*DoH).Query(0xc0005b63c0, {0x15dbe68, 0x1f4ad00}, {0xc000612408, 0x12}, {0x15cf0e0, 0x1}, {0x0, 0x0, 0x0})
   /home/antix/work/elementum/proxy/resolver.go:157 +0x5af
github.com/elgatito/elementum/proxy.resolveAddr({0xc000612408, 0x12})
   /home/antix/work/elementum/proxy/dns.go:118 +0x3c7
github.com/elgatito/elementum/proxy.CustomDialContext({0x15dbc70, 0x1f4ad00}, {0x14579fb, 0x3}, {0xc000612408, 0x16})
   /home/antix/work/elementum/proxy/client.go:80 +0x145
net/http.(*Transport).dial(0x0?, {0x15dbc70?, 0x1f4ad00?}, {0x14579fb?, 0xc0005a82c0?}, {0xc000612408?, 0x4c1e6a?})
   /snap/go/10585/src/net/http/transport.go:1187 +0xd2
net/http.(*Transport).dialConn(0xc0004077c0, {0x15dbc70, 0x1f4ad00}, {{}, 0x0, {0xc000502f00, 0x5}, {0xc000612408, 0x16}, 0x0})
   /snap/go/10585/src/net/http/transport.go:1648 +0x7e8
```

для https://github.com/elgatito/elementum/pull/126