### PR TITLE
Fix reqapi missing errors

### DIFF
--- a/util/ratelimit.go
+++ b/util/ratelimit.go
@@ -31,7 +31,6 @@ type RateLimiter struct {
 var (
 	ErrExceeded = errors.New("Rate-Limit Exceeded")
 	ErrNotFound = errors.New("Not Found")
-	ErrHTTP     = errors.New("HTTP error")
 )
 
 // NewRateLimiter creates a new rate limiter for the limit and interval.

--- a/util/reqapi/request.go
+++ b/util/reqapi/request.go
@@ -238,7 +238,7 @@ func (r *Request) Do() (err error) {
 				continue
 			} else if r.ResponseStatusCode < 200 || r.ResponseStatusCode >= 300 {
 				log.Errorf("Bad status getting %s with %+v on %s: %d/%s", r.Description, r.Params, r.URL, r.ResponseStatusCode, r.ResponseStatus)
-				err = util.ErrHTTP
+				err = errors.New(r.ResponseStatus)
 				r.Error(err)
 				return err
 			}


### PR DESCRIPTION
после перехода на reqapi потерялись сообщения ошибок
вместо `401/401 Unauthorized` пишет в UI `HTTP error` , что очевидно не даёт пользователю понимания почему проблема.
например у меня отвалилась авторизация тракта а мне выдало просто `HTTP error`.
ещё такая же беда с ошибками 500 - тоже теряется сообщение.
```
ERRO  reqapi       ▶ func2            [0mBad status getting Last Activities with map[] on https://api.trakt.tv/sync/last_activities: 401/401 Unauthorized
WARN  trakt        ▶ WatchedShowsProgress  [0mCannot get activities: HTTP error
```

сделал мелкий фикс - работает.