### PR TITLE
Prefer Romaji titles, Add Credits to tmdb.Season, Set Trailer in all tmdb video types

### DIFF
--- a/providers/xbmc.go
+++ b/providers/xbmc.go
@@ -400,12 +400,10 @@ func (as *AddonSearcher) GetEpisodeSearchObject(show *tmdb.Show, episode *tmdb.E
 			// try to find title in Romaji for anime
 			if lang == "jp" && strings.ToLower(title.Type) == "romaji" {
 				romaji = sObject.Titles[lang]
-				log.Debugf("Found Romaji title for anime: %s", romaji)
 			}
 		}
 	}
 	if romaji != "" {
-		log.Debugf("Set Romaji title for anime: %s", romaji)
 		sObject.Titles["jp"] = romaji
 	}
 

--- a/providers/xbmc.go
+++ b/providers/xbmc.go
@@ -226,6 +226,7 @@ func (as *AddonSearcher) GetMovieSearchObject(movie *tmdb.Movie) *MovieSearchObj
 	sObject.Titles[strings.ToLower(config.Get().Language)] = NormalizeTitle(movie.GetTitle())
 
 	// Collect titles from AlternativeTitles
+	var romaji string
 	if movie.AlternativeTitles != nil && movie.AlternativeTitles.Titles != nil {
 		for _, title := range movie.AlternativeTitles.Titles {
 			lang := strings.ToLower(title.Iso3166_1)
@@ -233,7 +234,14 @@ func (as *AddonSearcher) GetMovieSearchObject(movie *tmdb.Movie) *MovieSearchObj
 			if lang == "us" {
 				sObject.Titles["en"] = sObject.Titles[lang]
 			}
+			// try to find title in Romaji for anime
+			if lang == "jp" && strings.ToLower(title.Type) == "romaji" {
+				romaji = sObject.Titles[lang]
+			}
 		}
+	}
+	if romaji != "" {
+		sObject.Titles["jp"] = romaji
 	}
 
 	// Collect titles from Translations
@@ -275,6 +283,7 @@ func (as *AddonSearcher) GetSeasonSearchObject(show *tmdb.Show, season *tmdb.Sea
 	sObject.Titles[strings.ToLower(config.Get().Language)] = NormalizeTitle(show.GetName())
 
 	// Collect titles from AlternativeTitles
+	var romaji string
 	if show.AlternativeTitles != nil && show.AlternativeTitles.Titles != nil {
 		for _, title := range show.AlternativeTitles.Titles {
 			lang := strings.ToLower(title.Iso3166_1)
@@ -282,7 +291,14 @@ func (as *AddonSearcher) GetSeasonSearchObject(show *tmdb.Show, season *tmdb.Sea
 			if lang == "us" {
 				sObject.Titles["en"] = sObject.Titles[lang]
 			}
+			// try to find title in Romaji for anime
+			if lang == "jp" && strings.ToLower(title.Type) == "romaji" {
+				romaji = sObject.Titles[lang]
+			}
 		}
+	}
+	if romaji != "" {
+		sObject.Titles["jp"] = romaji
 	}
 
 	// Collect titles from Translations
@@ -373,6 +389,7 @@ func (as *AddonSearcher) GetEpisodeSearchObject(show *tmdb.Show, episode *tmdb.E
 	sObject.Titles[strings.ToLower(config.Get().Language)] = NormalizeTitle(show.GetName())
 
 	// Collect titles from AlternativeTitles
+	var romaji string
 	if show.AlternativeTitles != nil && show.AlternativeTitles.Titles != nil {
 		for _, title := range show.AlternativeTitles.Titles {
 			lang := strings.ToLower(title.Iso3166_1)
@@ -380,7 +397,16 @@ func (as *AddonSearcher) GetEpisodeSearchObject(show *tmdb.Show, episode *tmdb.E
 			if lang == "us" {
 				sObject.Titles["en"] = sObject.Titles[lang]
 			}
+			// try to find title in Romaji for anime
+			if lang == "jp" && strings.ToLower(title.Type) == "romaji" {
+				romaji = sObject.Titles[lang]
+				log.Debugf("Found Romaji title for anime: %s", romaji)
+			}
 		}
+	}
+	if romaji != "" {
+		log.Debugf("Set Romaji title for anime: %s", romaji)
+		sObject.Titles["jp"] = romaji
 	}
 
 	// Collect titles from Translations

--- a/tmdb/episode.go
+++ b/tmdb/episode.go
@@ -32,7 +32,7 @@ func GetEpisode(showID int, seasonNumber int, episodeNumber int, language string
 		URL: fmt.Sprintf("/tv/%d/season/%d/episode/%d", showID, seasonNumber, episodeNumber),
 		Params: napping.Params{
 			"api_key":                apiKey,
-			"append_to_response":     "credits,images,videos,alternative_titles,translations,external_ids,trailers",
+			"append_to_response":     "credits,images,videos,translations,external_ids",
 			"include_image_language": languagesList,
 			"include_video_language": languagesList,
 			"language":               language,
@@ -183,13 +183,14 @@ func (episode *Episode) ToListItem(show *Show, season *Season) *xbmc.ListItem {
 
 	episode.SetArt(show, season, item)
 
+	SetTrailer(&episode.Entity, item)
+
 	if season != nil && episode.Credits == nil && season.Credits != nil {
 		episode.Credits = season.Credits
 	}
 	if episode.Credits == nil && show.Credits != nil {
 		episode.Credits = show.Credits
 	}
-
 	if episode.Credits != nil {
 		item.CastMembers = episode.Credits.GetCastMembers()
 		item.Info.Director = episode.Credits.GetDirectors()

--- a/tmdb/movie.go
+++ b/tmdb/movie.go
@@ -13,7 +13,6 @@ import (
 	"github.com/elgatito/elementum/fanart"
 	"github.com/elgatito/elementum/library/playcount"
 	"github.com/elgatito/elementum/library/uid"
-	"github.com/elgatito/elementum/util"
 	"github.com/elgatito/elementum/util/reqapi"
 	"github.com/elgatito/elementum/xbmc"
 
@@ -73,7 +72,7 @@ func GetMovieByID(movieID string, language string) *Movie {
 		URL: fmt.Sprintf("/movie/%s", movieID),
 		Params: napping.Params{
 			"api_key":                apiKey,
-			"append_to_response":     "credits,images,alternative_titles,translations,external_ids,trailers,release_dates",
+			"append_to_response":     "credits,images,videos,translations,external_ids,alternative_titles,release_dates",
 			"include_image_language": languagesList,
 			"include_video_language": languagesList,
 			"language":               language,
@@ -487,12 +486,7 @@ func (movie *Movie) ToListItem() *xbmc.ListItem {
 
 	movie.SetArt(item)
 
-	if movie.Trailers != nil {
-		for _, trailer := range movie.Trailers.Youtube {
-			item.Info.Trailer = util.TrailerURL(trailer.Source)
-			break
-		}
-	}
+	SetTrailer(&movie.Entity, item)
 
 	for _, language := range movie.SpokenLanguages {
 		item.StreamInfo = &xbmc.StreamInfo{

--- a/tmdb/season.go
+++ b/tmdb/season.go
@@ -259,6 +259,15 @@ func (season *Season) ToListItem(show *Show) *xbmc.ListItem {
 
 	season.SetArt(show, item)
 
+	if season.Credits == nil && show.Credits != nil {
+		season.Credits = show.Credits
+	}
+	if season.Credits != nil {
+		item.CastMembers = show.Credits.GetCastMembers()
+		item.Info.Director = show.Credits.GetDirectors()
+		item.Info.Writer = show.Credits.GetWriters()
+	}
+
 	return item
 }
 

--- a/tmdb/season.go
+++ b/tmdb/season.go
@@ -34,7 +34,7 @@ func GetSeason(showID int, seasonNumber int, language string, seasonsCount int, 
 		URL: fmt.Sprintf("/tv/%d/season/%d", showID, seasonNumber),
 		Params: napping.Params{
 			"api_key":                apiKey,
-			"append_to_response":     "credits,images,videos,external_ids,alternative_titles,translations,trailers",
+			"append_to_response":     "credits,images,videos,translations,external_ids",
 			"include_image_language": languagesList,
 			"include_video_language": languagesList,
 			"language":               language,
@@ -258,6 +258,8 @@ func (season *Season) ToListItem(show *Show) *xbmc.ListItem {
 	}
 
 	season.SetArt(show, item)
+
+	SetTrailer(&season.Entity, item)
 
 	if season.Credits == nil && show.Credits != nil {
 		season.Credits = show.Credits

--- a/tmdb/show.go
+++ b/tmdb/show.go
@@ -131,7 +131,7 @@ func GetShow(showID int, language string) (show *Show) {
 		URL: fmt.Sprintf("/tv/%d", showID),
 		Params: napping.Params{
 			"api_key":                apiKey,
-			"append_to_response":     "credits,images,alternative_titles,translations,external_ids,content_ratings",
+			"append_to_response":     "credits,images,videos,translations,external_ids,alternative_titles,content_ratings",
 			"include_image_language": languagesList,
 			"include_video_language": languagesList,
 			"language":               language,
@@ -602,6 +602,8 @@ func (show *Show) ToListItem() *xbmc.ListItem {
 	}
 
 	show.SetArt(item)
+
+	SetTrailer(&show.Entity, item)
 
 	if config.Get().ShowUnwatchedEpisodesNumber {
 		watchedEpisodes := show.CountWatchedEpisodesNumber()

--- a/tmdb/tmdb.go
+++ b/tmdb/tmdb.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/elgatito/elementum/cache"
 	"github.com/elgatito/elementum/config"
+	"github.com/elgatito/elementum/util"
 	"github.com/elgatito/elementum/util/event"
 	"github.com/elgatito/elementum/util/reqapi"
 	"github.com/elgatito/elementum/xbmc"
@@ -430,4 +431,15 @@ func GetUserLanguages() (languagesList string) {
 	languagesList = fmt.Sprintf("%s,null", languagesList)
 
 	return
+}
+
+func SetTrailer(entity *Entity, item *xbmc.ListItem) {
+	if entity.Videos != nil {
+		for _, trailer := range entity.Videos.Videos {
+			if trailer.Type == "Trailer" && trailer.Site == "YouTube" {
+				item.Info.Trailer = util.TrailerURL(trailer.Key)
+				break
+			}
+		}
+	}
 }

--- a/tmdb/types.go
+++ b/tmdb/types.go
@@ -268,6 +268,7 @@ type ContentRating struct {
 type AlternativeTitle struct {
 	Iso3166_1 string `json:"iso_3166_1"`
 	Title     string `json:"title"`
+	Type      string `json:"type"`
 }
 
 // Language ...

--- a/tmdb/types.go
+++ b/tmdb/types.go
@@ -22,7 +22,6 @@ type EpisodeList []*Episode
 type Movie struct {
 	Entity
 
-	ExternalIDs         *ExternalIDs  `json:"external_ids"`
 	FanArt              *fanart.Movie `json:"fanart"`
 	IMDBId              string        `json:"imdb_id"`
 	Popularity          float64       `json:"-"`
@@ -37,16 +36,6 @@ type Movie struct {
 		Titles []*AlternativeTitle `json:"titles"`
 	} `json:"alternative_titles"`
 
-	Translations *struct {
-		Translations []*Translation `json:"translations"`
-	} `json:"translations"`
-
-	Trailers *struct {
-		Youtube []*Trailer `json:"youtube"`
-	} `json:"trailers"`
-
-	Credits *Credits `json:"credits,omitempty"`
-
 	ReleaseDates *ReleaseDatesResults `json:"release_dates"`
 }
 
@@ -55,7 +44,6 @@ type Show struct {
 	Entity
 
 	EpisodeRunTime      []int         `json:"episode_run_time"`
-	ExternalIDs         *ExternalIDs  `json:"external_ids"`
 	FanArt              *fanart.Show  `json:"fanart"`
 	Homepage            string        `json:"homepage"`
 	InProduction        bool          `json:"in_production"`
@@ -75,17 +63,13 @@ type Show struct {
 	LastEpisodeToAir *Episode `json:"last_episode_to_air"`
 	NextEpisodeToAir *Episode `json:"next_episode_to_air"`
 
-	Translations *struct {
-		Translations []*Translation `json:"translations"`
-	} `json:"translations"`
 	AlternativeTitles *struct {
 		Titles []*AlternativeTitle `json:"results"`
 	} `json:"alternative_titles"`
+
 	ContentRatings *struct {
 		Ratings []*ContentRating `json:"results"`
 	} `json:"content_ratings"`
-
-	Credits *Credits `json:"credits,omitempty"`
 
 	Seasons SeasonList `json:"seasons"`
 }
@@ -94,24 +78,9 @@ type Show struct {
 type Season struct {
 	Entity
 
-	AirDate      string       `json:"air_date"`
-	EpisodeCount int          `json:"episode_count,omitempty"`
-	ExternalIDs  *ExternalIDs `json:"external_ids"`
-	Season       int          `json:"season_number"`
-
-	AlternativeTitles *struct {
-		Titles []*AlternativeTitle `json:"titles"`
-	} `json:"alternative_titles"`
-
-	Translations *struct {
-		Translations []*Translation `json:"translations"`
-	} `json:"translations"`
-
-	Trailers *struct {
-		Youtube []*Trailer `json:"youtube"`
-	} `json:"trailers"`
-
-	Credits *Credits `json:"credits,omitempty"`
+	AirDate      string `json:"air_date"`
+	EpisodeCount int    `json:"episode_count,omitempty"`
+	Season       int    `json:"season_number"`
 
 	Episodes EpisodeList `json:"episodes"`
 }
@@ -120,26 +89,11 @@ type Season struct {
 type Episode struct {
 	Entity
 
-	AirDate       string       `json:"air_date"`
-	EpisodeNumber int          `json:"episode_number"`
-	ExternalIDs   *ExternalIDs `json:"external_ids"`
-	Runtime       int          `json:"runtime"`
-	SeasonNumber  int          `json:"season_number"`
-	StillPath     string       `json:"still_path"`
-
-	AlternativeTitles *struct {
-		Titles []*AlternativeTitle `json:"titles"`
-	} `json:"alternative_titles"`
-
-	Translations *struct {
-		Translations []*Translation `json:"translations"`
-	} `json:"translations"`
-
-	Trailers *struct {
-		Youtube []*Trailer `json:"youtube"`
-	} `json:"trailers"`
-
-	Credits *Credits `json:"credits,omitempty"`
+	AirDate       string `json:"air_date"`
+	EpisodeNumber int    `json:"episode_number"`
+	Runtime       int    `json:"runtime"`
+	SeasonNumber  int    `json:"season_number"`
+	StillPath     string `json:"still_path"`
 }
 
 // Entity ...
@@ -161,6 +115,18 @@ type Entity struct {
 	VoteCount        int       `json:"vote_count"`
 
 	Images *Images `json:"images,omitempty"`
+
+	Translations *struct {
+		Translations []*Translation `json:"translations"`
+	} `json:"translations"`
+
+	Videos *struct {
+		Videos []*Trailer `json:"results"`
+	} `json:"videos"`
+
+	Credits *Credits `json:"credits,omitempty"`
+
+	ExternalIDs *ExternalIDs `json:"external_ids"`
 }
 
 // EntityList ...
@@ -320,10 +286,10 @@ type List struct {
 
 // Trailer ...
 type Trailer struct {
-	Name   string `json:"name"`
-	Size   string `json:"size"`
-	Source string `json:"source"`
-	Type   string `json:"type"`
+	Name string `json:"name"`
+	Key  string `json:"key"`
+	Type string `json:"type"`
+	Site string `json:"site"`
 }
 
 // ReleaseDatesResults ...


### PR DESCRIPTION
Collect titles хотел вынести в функции, но там косяк в том, что у фильма и шоу разные названия полей для alternative_titles (у серии/сезона их нет) - `titles` vs `results` - так что в Entity не вынести это поле, видимо так исторически сложилось у них в api. ну и в GeneralSearchObject пришлось бы Title тоже переносить из конкртеных типов, а там вроде только техническая инфа, а не инфа о видео.

trailers это что-то старое только для фильмов, videos новое для всех типов.