### PR TITLE
Update list of peer ids and user agents.

### DIFF
--- a/util/ident/ident.go
+++ b/util/ident/ident.go
@@ -47,7 +47,7 @@ func DefaultUserAgent() string {
 
 // DefaultPeerID return default PeerID
 func DefaultPeerID() string {
-	return "-GT0001-"
+	return "-LT1100-"
 }
 
 // PeerIDRandom generates random peer id
@@ -79,7 +79,7 @@ func GetUserAndPeer() (peerID, userAgent string) {
 			peerID = "-TR1930-"
 			return
 		case 2:
-			userAgent = "libtorrent (Rasterbar) 1.1.0"
+			userAgent = "libtorrent/1.1.0.0"
 			peerID = "-LT1100-"
 			return
 		case 3:
@@ -87,16 +87,16 @@ func GetUserAndPeer() (peerID, userAgent string) {
 			peerID = "-BT7500-"
 			return
 		case 4:
-			userAgent = "BitTorrent/7.4.3"
-			peerID = "-BT7430-"
+			userAgent = "BitTorrent/7.9.9"
+			peerID = "-BT7990-"
 			return
 		case 5:
-			userAgent = "uTorrent/3.4.9"
-			peerID = "-UT3490-"
+			userAgent = "uTorrent/3.5.5"
+			peerID = "-UT3550-"
 			return
 		case 6:
-			userAgent = "uTorrent/3.2.0"
-			peerID = "-UT3200-"
+			userAgent = "uTorrent/3.6.0"
+			peerID = "-UT3600-"
 			return
 		case 7:
 			userAgent = "uTorrent/2.2.1"
@@ -107,20 +107,32 @@ func GetUserAndPeer() (peerID, userAgent string) {
 			peerID = "-TR2920-"
 			return
 		case 9:
-			userAgent = "Deluge/1.3.6.0"
-			peerID = "-DG1360-"
+			userAgent = "Deluge/1.3.6"
+			peerID = "-DE1360-"
 			return
 		case 10:
-			userAgent = "Deluge/1.3.12.0"
-			peerID = "-DG1312-"
+			userAgent = "Deluge/2.1.1 libtorrent/1.2.15.0"
+			peerID = "-DE211s-"
 			return
 		case 11:
 			userAgent = "Vuze/5.7.3.0"
-			peerID = "-VZ5730-"
+			peerID = "-AZ5730-"
+			return
+		case 12:
+			userAgent = "Transmission/4.05"
+			peerID = "-TR4050-"
+			return
+		case 13:
+			userAgent = "qBittorrent/3.3.9"
+			peerID = "-qB3390-"
+			return
+		case 14:
+			userAgent = "qBittorrent/4.6.4"
+			peerID = "-qB4640-"
 			return
 		default:
-			userAgent = "uTorrent/3.4.9"
-			peerID = "-UT3490-"
+			userAgent = "Transmission/1.93"
+			peerID = "-TR1930-"
 			return
 		}
 	}


### PR DESCRIPTION
it was quite hard to get accurate info. info used:

general
https://www.bittorrent.org/beps/bep_0020.html
https://github.com/webtorrent/bittorrent-peerid/blob/f00abec7bf8ef77b523a0fd1762ab89072b62274/index.js#L250


deluge
https://git.deluge-torrent.org/deluge/tree/deluge/core/core.py?h=deluge-1.3.6#n90
https://git.deluge-torrent.org/deluge/tree/deluge/core/core.py?h=deluge-1.3.6#n97
https://git.deluge-torrent.org/deluge/tree/deluge/core/core.py?h=deluge-2.1.1#n249
https://git.deluge-torrent.org/deluge/tree/deluge/core/core.py?h=deluge-2.1.1#n115

vuze
https://svn.vuze.com/public/client/tags/RELEASE_5730/azureus2/src/org/gudy/azureus2/core3/util/Constants.java

transmission
https://github.com/transmission/transmission/blob/6c1cee5f79d8bbdc78f96640b52e49441d70247c/update-version-h.sh#L54
https://github.com/transmission/transmission/blob/main/docs/Peer-ID-and-User-Agent.md

qBittorrent
https://github.com/qbittorrent/qBittorrent/wiki/Frequently-Asked-Questions#What_is_qBittorrent_Peer_ID
https://github.com/qbittorrent/qBittorrent/blob/4d8713ce110d80f995212fb7a779fe16504fb91d/src/base/bittorrent/sessionimpl.cpp#L119

libtorrent
https://www.libtorrent.org/reference-Settings.html
https://github.com/arvidn/libtorrent/blob/2921caf95e851a7918026dc159b1717ef5045f30/src/settings_pack.cpp#L130
https://github.com/arvidn/libtorrent/blob/2921caf95e851a7918026dc159b1717ef5045f30/include/libtorrent/version.hpp#L46

misc
https://www.downloadprivacy.com/wp-content/uploads/2020/04/vuze-peers-ip-address.png
https://www.downloadprivacy.com/wp-content/uploads/2020/07/torrent-peers-ip-addresses.png

fixes https://github.com/elgatito/plugin.video.elementum/issues/1040