### PR TITLE
Do not overwrite OriginalLanguage title with AlternativeTitles

### DIFF
--- a/providers/xbmc.go
+++ b/providers/xbmc.go
@@ -222,9 +222,6 @@ func (as *AddonSearcher) GetMovieSearchObject(movie *tmdb.Movie) *MovieSearchObj
 		}
 	}
 
-	sObject.Titles[strings.ToLower(movie.OriginalLanguage)] = NormalizeTitle(sObject.Titles["source"])
-	sObject.Titles[strings.ToLower(config.Get().Language)] = NormalizeTitle(movie.GetTitle())
-
 	// Collect titles from AlternativeTitles
 	if movie.AlternativeTitles != nil && movie.AlternativeTitles.Titles != nil {
 		for _, title := range movie.AlternativeTitles.Titles {
@@ -247,6 +244,9 @@ func (as *AddonSearcher) GetMovieSearchObject(movie *tmdb.Movie) *MovieSearchObj
 			sObject.Titles[strings.ToLower(tr.Iso639_1)] = NormalizeTitle(tr.Data.Title)
 		}
 	}
+
+	sObject.Titles[strings.ToLower(movie.OriginalLanguage)] = NormalizeTitle(sObject.Titles["source"])
+	sObject.Titles[strings.ToLower(config.Get().Language)] = NormalizeTitle(movie.GetTitle())
 
 	sObject.ProxyURL = config.Get().ProxyURL
 	sObject.ElementumURL = ip.ElementumURL()
@@ -271,9 +271,6 @@ func (as *AddonSearcher) GetSeasonSearchObject(show *tmdb.Show, season *tmdb.Sea
 		Anime:      show.IsAnime(),
 	}
 
-	sObject.Titles[strings.ToLower(show.OriginalLanguage)] = NormalizeTitle(sObject.Titles["source"])
-	sObject.Titles[strings.ToLower(config.Get().Language)] = NormalizeTitle(show.GetName())
-
 	// Collect titles from AlternativeTitles
 	if show.AlternativeTitles != nil && show.AlternativeTitles.Titles != nil {
 		for _, title := range show.AlternativeTitles.Titles {
@@ -296,6 +293,9 @@ func (as *AddonSearcher) GetSeasonSearchObject(show *tmdb.Show, season *tmdb.Sea
 			sObject.Titles[strings.ToLower(tr.Iso639_1)] = NormalizeTitle(tr.Data.Name)
 		}
 	}
+
+	sObject.Titles[strings.ToLower(show.OriginalLanguage)] = NormalizeTitle(sObject.Titles["source"])
+	sObject.Titles[strings.ToLower(config.Get().Language)] = NormalizeTitle(show.GetName())
 
 	sObject.ProxyURL = config.Get().ProxyURL
 	sObject.ElementumURL = ip.ElementumURL()
@@ -369,9 +369,6 @@ func (as *AddonSearcher) GetEpisodeSearchObject(show *tmdb.Show, episode *tmdb.E
 		Anime:          show.IsAnime(),
 	}
 
-	sObject.Titles[strings.ToLower(show.OriginalLanguage)] = NormalizeTitle(sObject.Titles["source"])
-	sObject.Titles[strings.ToLower(config.Get().Language)] = NormalizeTitle(show.GetName())
-
 	// Collect titles from AlternativeTitles
 	if show.AlternativeTitles != nil && show.AlternativeTitles.Titles != nil {
 		for _, title := range show.AlternativeTitles.Titles {
@@ -394,6 +391,9 @@ func (as *AddonSearcher) GetEpisodeSearchObject(show *tmdb.Show, episode *tmdb.E
 			sObject.Titles[strings.ToLower(tr.Iso639_1)] = NormalizeTitle(tr.Data.Name)
 		}
 	}
+
+	sObject.Titles[strings.ToLower(show.OriginalLanguage)] = NormalizeTitle(sObject.Titles["source"])
+	sObject.Titles[strings.ToLower(config.Get().Language)] = NormalizeTitle(show.GetName())
 
 	sObject.ProxyURL = config.Get().ProxyURL
 	sObject.ElementumURL = ip.ElementumURL()


### PR DESCRIPTION
We should set title["X"X] to "OriginalLanguage" if "XX" is empty and "OriginalLanguage"="XX", otherwise it can be overwritten with some irrelevant title from AlternativeTitles, see https://github.com/elgatito/script.elementum.burst/issues/424 for example.


Before:
```
Translated titles from Elementum: {'al': 'froni i shpatave', 'ar': 'صراع العروش', 'az': 'taxt oyunları', 'be': 'гульня тронаў', 'bg': 'игра на тронове', 'br': 'a guerra dos tronos', 'by': 'гульня тронаў', 'ca': 'joc de trons', 'cn': '权力的游戏', 'co': 'juego de tronos', 'cs': 'hra o trůny', 'cz': 'hra o trůny', 'de': 'paihnidi tou stemmatos', 'ee': 'troonide mäng', 'en': 'got', 'eo': 'ludo de tronoj', 'es': 'joc de trons', 'et': 'troonide mäng', 'fa': 'بازی تاج وتخت', 'fr': 'le trône de fer', 'ge': 'სამეფო კარის თამაშები', 'gr': 'παιχνίδι του στέμματος', 'he': 'משחקי הכס', 'hk': '權力遊戲', 'hr': 'igra prijestolja', 'hu': 'trónok harca', 'id': 'game of thrones', 'il': 'משחקי הכס', 'in': 'அர யண வ ள ய ட ட', 'ir': 'بازی تاج وتخت', 'is': 'krúnuleikar', 'it': 'il trono di spade', 'ja': 'ゲーム オブ スローンズ', 'jp': 'ゲーム オブ スローンズ', 'ka': 'სამეფო კარის თამაშები', 'ko': '왕좌의 게임', 'kr': '왕좌의 게임', 'lb': 'spill vun instanzen', 'lt': 'sostų karai', 'lv': 'troņu spēle', 'mk': 'игра на тронови', 'ml': 'ഗ യ ഓഫ ത ര ൺസ', 'mx': 'juego de tronos', 'original': 'game of thrones', 'pl': 'gra o tron', 'pt': 'a guerra dos tronos', 'ro': 'urzeala tronurilor', 'rs': 'игра престола', 'ru': 'игра престолов', 'sa': 'صراع العروش', 'si': 'igra prestolov', 'sk': 'hra o tróny', 'sl': 'igra prestolov', 'so': 'ciyaarta boqorrada', 'source': 'Game of Thrones', 'sr': 'игра престола', 'ta': 'அர யண வ ள ய ட ட', 'th': 'มหาศ กช งบ ลล งก', 'tr': 'taht oyunları', 'tw': '冰與火之歌 權力遊戲', 'ua': 'гра престолів', 'uk': 'гра престолів', 'us': 'got', 'uz': 'taxtlar oʻyini', 'vi': 'trò chơi vương quyền', 'vn': 'trò chơi vương quyền', 'zh': '權力遊戲'}
[rutor] Using translated 'en' title 'got'
```

After:
```
[script.elementum.burst] Translated titles from Elementum: {'al': 'froni i shpatave', 'ar': 'صراع العروش', 'az': 'taxt oyunları', 'be': 'гульня тронаў', 'bg': 'игра на тронове', 'br': 'a guerra dos tronos', 'by': 'гульня тронаў', 'ca': 'joc de trons', 'cn': '权力的游戏', 'co': 'juego de tronos', 'cs': 'hra o trůny', 'cz': 'hra o trůny', 'de': 'paihnidi tou stemmatos', 'ee': 'troonide mäng', 'en': 'game of thrones', 'eo': 'ludo de tronoj', 'es': 'joc de trons', 'et': 'troonide mäng', 'fa': 'بازی تاج وتخت', 'fr': 'le trône de fer', 'ge': 'სამეფო კარის თამაშები', 'gr': 'παιχνίδι του στέμματος', 'he': 'משחקי הכס', 'hk': '權力遊戲', 'hr': 'igra prijestolja', 'hu': 'trónok harca', 'id': 'game of thrones', 'il': 'משחקי הכס', 'in': 'அர யண வ ள ய ட ட', 'ir': 'بازی تاج وتخت', 'is': 'krúnuleikar', 'it': 'il trono di spade', 'ja': 'ゲーム オブ スローンズ', 'jp': 'ゲーム オブ スローンズ', 'ka': 'სამეფო კარის თამაშები', 'ko': '왕좌의 게임', 'kr': '왕좌의 게임', 'lb': 'spill vun instanzen', 'lt': 'sostų karai', 'lv': 'troņu spēle', 'mk': 'игра на тронови', 'ml': 'ഗ യ ഓഫ ത ര ൺസ', 'mx': 'juego de tronos', 'original': 'game of thrones', 'pl': 'gra o tron', 'pt': 'a guerra dos tronos', 'ro': 'urzeala tronurilor', 'rs': 'игра престола', 'ru': 'игра престолов', 'sa': 'صراع العروش', 'si': 'igra prestolov', 'sk': 'hra o tróny', 'sl': 'igra prestolov', 'so': 'ciyaarta boqorrada', 'source': 'Game of Thrones', 'sr': 'игра престола', 'ta': 'அர யண வ ள ய ட ட', 'th': 'มหาศ กช งบ ลล งก', 'tr': 'taht oyunları', 'tw': '冰與火之歌 權力遊戲', 'ua': 'гра престолів', 'uk': 'гра престолів', 'us': 'got', 'uz': 'taxtlar oʻyini', 'vi': 'trò chơi vương quyền', 'vn': 'trò chơi vương quyền', 'zh': '權力遊戲'}
[script.elementum.burst] [rutor] Using translated 'en' title 'game of thrones'
```

the history of title logic is:
https://github.com/elgatito/elementum/commit/45e4dafd054ff10631aa2cefadcd15b93f650162#diff-e4e177b2764d7fd0fb5c4baa63011e37a160ff5b6d099c07fa3ce23086d23a86
https://github.com/elgatito/elementum/commit/0f1376a1685962c3c2f542f00695e958aeaea176#diff-e4e177b2764d7fd0fb5c4baa63011e37a160ff5b6d099c07fa3ce23086d23a86
https://github.com/elgatito/elementum/commit/b5481279b679ccd27a12d38b2617cd9ea789a487#diff-e4e177b2764d7fd0fb5c4baa63011e37a160ff5b6d099c07fa3ce23086d23a86
and finally here for some reason it was decided to overwrite OriginalLanguage title with AlternativeTitles
https://github.com/elgatito/elementum/commit/eab0122a0495ca4cb5b82155c774612f35c4a887
but i have not seen use cases where it can be useful, since AlternativeTitles rarely has useful info (except for romaji for anime).
if there was some legit use case - then we can try to make more complex logic that will cover both use cases.


fixes https://github.com/elgatito/script.elementum.burst/issues/424