### PR TITLE
Do not run watchParentProcess for daemon mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -238,7 +238,10 @@ func main() {
 			time.Sleep(1 * time.Second)
 		}
 	}
-	go watchParentProcess()
+	// If we run with custom config, then we run as daemon, thus no need to watch for parent process
+	if config.Args.ConfigPath == "" {
+		go watchParentProcess()
+	}
 
 	// Make sure HTTP mux is empty
 	http.DefaultServeMux = new(http.ServeMux)


### PR DESCRIPTION
If we run with custom config, then we run as daemon, thus no need to watch for parent process.
for https://github.com/elgatito/plugin.video.elementum/issues/1048