### PR TITLE
Check if current PID is equal to old PID in lockfile. Remove lockfile at shutdown.

### DIFF
--- a/lockfile/lockfile.go
+++ b/lockfile/lockfile.go
@@ -60,7 +60,7 @@ func (lf *LockFile) Lock() (int, error) {
 			return pid, err
 		}
 
-		if running {
+		if running && pid != ownPID { // e.g. Flatpak assigns same PID to elementum every run
 			return pid, ErrLocked
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -220,6 +220,8 @@ func main() {
 		// Wait until service is finally stopped
 		<-s.CloserNotifier.C()
 
+		lock.Unlock()
+
 		log.Info("Goodbye")
 
 		// If we don't give an exit code - python treat as well done and not


### PR DESCRIPTION
1. Flatpak assigns same PID to elementum every run, so we should check if PID is the same and if so - we consider that lockfile is NOT locked.

Fixes https://github.com/elgatito/plugin.video.elementum/issues/1058

Also see https://github.com/elgatito/plugin.video.elementum/pull/1062

2. lockfile was supposed to be removed via `defer`
https://github.com/elgatito/elementum/blob/de4ac744eaa7e26131f4d4bea3da0d4ed01348f0/main.go#L184
https://github.com/elgatito/elementum/blob/de4ac744eaa7e26131f4d4bea3da0d4ed01348f0/lockfile/lockfile.go#L88

but shutdown was made as "coroutine" so it never reached the end of main, so it never was removed.
on classic environment (win/lin/android) this mistake was not the issue, but with flatpak it became visible that we **never** remove lockfile.