### PR TITLE
Add bittorrent ports to status page.

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -92,7 +92,7 @@ func Routes(s *bittorrent.Service, shutdown func(code int)) *gin.Engine {
 	r.GET("/changelog", Changelog)
 	r.GET("/donate", Donate)
 	r.GET("/settings/:addon", Settings)
-	r.GET("/status", Status)
+	r.GET("/status", Status(s))
 
 	r.Any("/info", s.ClientInfo)
 	r.Any("/info/*ident", s.ClientInfo)


### PR DESCRIPTION
For example, this can be useful if you want to add elementum as peer to your PC's bittorrent client (usually it is not added instantly, only after a while). I do this for slow torrents sometimes.
depends on https://github.com/elgatito/plugin.video.elementum/pull/1063

![elementum bittorrent ports](https://github.com/user-attachments/assets/e49b5cd7-13b3-4ac5-b545-46fdbacfe88f)
