### PR TITLE
Do not print libtorrent tracker_notification category, refactor other conditions.

### DIFF
--- a/bittorrent/service.go
+++ b/bittorrent/service.go
@@ -1171,14 +1171,13 @@ func (s *Service) logAlerts() {
 
 			// Skipping Tracker communication, Save_Resume, UDP errors
 			// No need to spam logs.
-			if alert.Type == int(lt.SaveResumeDataAlertAlertType) ||
+			if alert.Category&int(lt.AlertBlockProgressNotification) != 0 ||
+				alert.Category&int(lt.AlertDhtLogNotification) != 0 ||
+				alert.Category&int(lt.AlertTrackerNotification) != 0 ||
+				alert.Type == int(lt.SaveResumeDataAlertAlertType) ||
 				alert.Type == int(lt.UdpErrorAlertAlertType) ||
-				alert.Type == int(lt.AlertBlockProgressNotification) ||
-				alert.Type == int(lt.TrackerReplyAlertAlertType) ||
-				alert.Type == int(lt.DhtReplyAlertAlertType) ||
 				alert.Type == int(lt.StateChangedAlertAlertType) ||
-				alert.Type == int(lt.TorrentFinishedAlertAlertType) ||
-				alert.Type == int(lt.DhtLogAlertAlertType) {
+				alert.Type == int(lt.TorrentFinishedAlertAlertType) {
 				continue
 			} else if alert.Category&int(lt.AlertErrorNotification) != 0 {
 				log.Errorf("%s: %s", alert.What, alert.Message)


### PR DESCRIPTION
Do not print libtorrent tracker_notification category, refactor other conditions.

found during investigating https://github.com/elgatito/plugin.video.elementum/issues/1068 

docs used:
https://github.com/arvidn/libtorrent/blob/RC_1_1/include/libtorrent/alert_types.hpp
https://www.rasterbar.com/products/libtorrent/reference-Alerts.html#alert-category-t

before:
```
$ grep -Po "(?<=logAlerts        )[^:]*" ~/.kodi/temp/kodi.log| sort | uniq -c
      7 add_torrent_alert
      7 cache_flushed_alert
      2 external_ip_alert
      5 listen_succeeded_alert
      7 performance_alert
      7 torrent_checked_alert
      1 torrent_paused_alert
      1 torrent_resumed_alert
    388 tracker_announce_alert
    213 tracker_error_alert
     41 tracker_warning_alert
```
after:
```
$ grep -Po "(?<=logAlerts        )[^:]*" ~/.kodi/temp/kodi.log| sort | uniq -c
      7 add_torrent_alert
      7 cache_flushed_alert
      1 external_ip_alert
      1 hash_failed_alert
      5 listen_succeeded_alert
     19 performance_alert
      7 torrent_checked_alert
      1 torrent_paused_alert
      1 torrent_resumed_alert
```