### PR TITLE
Add more filters for logAlerts.

### DIFF
--- a/bittorrent/service.go
+++ b/bittorrent/service.go
@@ -1175,6 +1175,10 @@ func (s *Service) logAlerts() {
 			if alert.Category&int(lt.AlertBlockProgressNotification) != 0 ||
 				alert.Category&int(lt.AlertDhtLogNotification) != 0 ||
 				alert.Category&int(lt.AlertTrackerNotification) != 0 ||
+				alert.Category&int(lt.AlertPeerLogNotification) != 0 ||
+				alert.Category&int(lt.AlertPickerLogNotification) != 0 ||
+				alert.Category&int(lt.AlertTorrentLogNotification) != 0 ||
+				alert.Type == int(lt.PieceFinishedAlertAlertType) ||
 				alert.Type == int(lt.SaveResumeDataAlertAlertType) ||
 				alert.Type == int(lt.UdpErrorAlertAlertType) ||
 				alert.Type == int(lt.StateChangedAlertAlertType) ||


### PR DESCRIPTION
Filter more libtorrent logs:
AlertPeerLogNotification (Category)
AlertTorrentLogNotification (Category)
AlertPickerLogNotification (Category)
PieceFinishedAlertAlertType (Type)

before:
https://github.com/elgatito/elementum/pull/140#issuecomment-2395510616

after
```
$ grep -Po "(?<=logAlerts        )[^:]*" ~/.kodi/temp/kodi.log| sort | uniq -c
     11 add_torrent_alert
     12 cache_flushed_alert
      1 dht_bootstrap_alert
    109 dht_get_peers_alert
    334 dht_outgoing_get_peers_alert
      1 external_ip_alert
     30 file_completed_alert
      3 incoming_connection_alert
      5 listen_succeeded_alert
   1540 log_alert
      1 metadata_received_alert
    407 peer_connect_alert
    408 peer_disconnected_alert
      7 peer_snubbed_alert
      4 peer_unsnubbed_alert
     26 performance_alert
      4 portmap_alert
     85 portmap_log_alert
    154 stats_alert
     11 torrent_checked_alert
      5 torrent_paused_alert
      5 torrent_resumed_alert
```

