### PR TITLE
Revert "Added a check for nil lockfile"

### DIFF
--- a/main.go
+++ b/main.go
@@ -220,9 +220,7 @@ func main() {
 		// Wait until service is finally stopped
 		<-s.CloserNotifier.C()
 
-		if lock != nil {
-			defer lock.Unlock()
-		}
+		lock.Unlock()
 
 		log.Info("Goodbye")
 


### PR DESCRIPTION
This reverts commit 3a2c613bf650a2edd617c7f6b587efe63f85c795.

With `defer` we never remove lock file.
You can check `.kodi/userdata/addon_data/plugin.video.elementum/`
or add `fmt.Printf("Removing lockfile: %s\n", lf.File)` to https://github.com/elgatito/elementum/blob/6edadd6334edec57c75fb0634ab0b666fc311f5d/lockfile/lockfile.go#L82
and check logs.