### PR TITLE
Always ask confirmation for "delete torrent" menu

### DIFF
--- a/api/torrents.go
+++ b/api/torrents.go
@@ -302,8 +302,7 @@ func ListTorrents(s *bittorrent.Service) gin.HandlerFunc {
 			item.ContextMenu = [][]string{
 				{"LOCALIZE[30230]", fmt.Sprintf("PlayMedia(%s)", playURL)},
 				torrentAction,
-				{"LOCALIZE[30232]", fmt.Sprintf("RunPlugin(%s)", URLForXBMC("/torrents/delete/%s", t.InfoHash()))},
-				{"LOCALIZE[30276]", fmt.Sprintf("RunPlugin(%s)", URLForXBMC("/torrents/delete/%s?files=true", t.InfoHash()))},
+				{"LOCALIZE[30232]", fmt.Sprintf("RunPlugin(%s)", URLForXBMC("/torrents/delete/%s?confirmation=true", t.InfoHash()))},
 				{"LOCALIZE[30308]", fmt.Sprintf("RunPlugin(%s)", URLForXBMC("/torrents/move/%s", t.InfoHash()))},
 				sessionAction,
 			}
@@ -588,7 +587,7 @@ func RemoveTorrent(s *bittorrent.Service) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		xbmcHost, _ := xbmc.GetXBMCHostWithContext(ctx)
 
-		deleteFiles := ctx.DefaultQuery("files", "false")
+		confirmation := ctx.DefaultQuery("confirmation", "false")
 
 		torrentID := ctx.Params.ByName("torrentId")
 		torrent, err := GetTorrentFromParam(s, torrentID)
@@ -597,7 +596,7 @@ func RemoveTorrent(s *bittorrent.Service) gin.HandlerFunc {
 			return
 		}
 
-		s.RemoveTorrent(xbmcHost, torrent, bittorrent.RemoveOptions{ForceDrop: true, ForceDelete: deleteFiles == "true"})
+		s.RemoveTorrent(xbmcHost, torrent, bittorrent.RemoveOptions{ForceConfirmation: confirmation == "true"})
 
 		xbmcHost.Refresh()
 		ctx.String(200, "")

--- a/bittorrent/types.go
+++ b/bittorrent/types.go
@@ -168,5 +168,6 @@ type RemoveOptions struct {
 	ForceKeepTorrentData bool
 	ForceDrop            bool
 	ForceDelete          bool
+	ForceConfirmation    bool
 	IsWatched            bool
 }


### PR DESCRIPTION
fixes https://github.com/elgatito/plugin.video.elementum/issues/961

Always ask confirmation when user choose "delete torrent" in menu in "Torrents":
![delete torrent confirmation](https://github.com/user-attachments/assets/84d2e061-8145-477d-af91-860cc35364cd)
![delete torrent files confirmation](https://github.com/user-attachments/assets/57d810cd-6e2d-48c7-b4fa-519a6e4be110)


i specifically used `DialogConfirmNonTimed` since delete is dangerous operation.