### PR TITLE
Fix double decode of file url

### DIFF
--- a/bittorrent/player.go
+++ b/bittorrent/player.go
@@ -1155,7 +1155,7 @@ func (btp *Player) InitAudio() {
 
 		for _, f := range btp.t.files {
 			if strings.Contains(f.Path, currentPath) && util.HasAudioExt(f.Path) {
-				collected = append(collected, ip.GetHTTPHost()+"/files/"+f.Path)
+				collected = append(collected, ip.GetHTTPHost()+"/files/"+util.EncodeFileURL(f.Path))
 			}
 		}
 

--- a/bittorrent/torrent_file.go
+++ b/bittorrent/torrent_file.go
@@ -488,6 +488,7 @@ func (t *TorrentFile) Download() ([]byte, error) {
 		for _, part := range parts[1:] {
 			if keyVal := strings.SplitN(part, "=", 2); len(keyVal) > 1 {
 				req.Header.Add(keyVal[0], keyVal[1])
+				log.Debugf("Added header %q: %q", keyVal[0], keyVal[1])
 			}
 		}
 	}

--- a/bittorrent/torrentfs.go
+++ b/bittorrent/torrentfs.go
@@ -67,9 +67,7 @@ func NewTorrentFS(service *Service, method string) *TorrentFS {
 }
 
 // Open ...
-func (tfs *TorrentFS) Open(uname string) (http.File, error) {
-	name := util.DecodeFileURL(uname)
-
+func (tfs *TorrentFS) Open(name string) (http.File, error) {
 	var file http.File
 	var err error
 


### PR DESCRIPTION
1. Remove `DecodeFileURL` from TorrentFS.Open()

URL is already decoded (you can print it to check, i guess it is decoded by library, although i have not found this in docs, but it is definitely already decoded), so if raw file path has special characters - then it will be unnecessarily "decoded" again and file will not be found.

e.g. if path has `%7C` in name. (it supposed to be `|` but was encoded by publishing software, i guess)

example of such strange file path:
https://animaunt.org/13543-napadenie-odinochki-na-inoy-mir.html
https://animaunt.org/13859-proschay-zhizn-drakona-zdravstvuy-zhizn-cheloveka.html
`Прощай, жизнь дракона. Здравствуй, жизнь человека %7C Sayounara Ryuusei, Konnichiwa Jinsei`
`Нападение одиночки на иной мир %7C Hitoribocchi no Isekai Kouryaku`

i tested my change on 16 different torrents - all ok.

2.  Add `EncodeFileURL` for Audio file 
like it was done for subtitles earlier https://github.com/elgatito/elementum/pull/52
and how it was done for video from the beggining.

3.  Add small debug message to TorrentFile.Download() to see what headers we add when we download `.torrent` file.