### PR TITLE
Add support of disable_tcp and disable_utp settings

### DIFF
--- a/bittorrent/service.go
+++ b/bittorrent/service.go
@@ -450,6 +450,17 @@ func (s *Service) configure() {
 		settings.SetInt("min_reconnect_time", 20)
 	}
 
+	if s.config.DisableTCP {
+		log.Info("Disabling TCP...")
+		settings.SetBool("enable_outgoing_tcp", false)
+		settings.SetBool("enable_incoming_tcp", false)
+	}
+	if s.config.DisableUTP {
+		log.Info("Disabling UTP...")
+		settings.SetBool("enable_outgoing_utp", false)
+		settings.SetBool("enable_incoming_utp", false)
+	}
+
 	var listenPorts []string
 	if s.config.ListenAutoDetectPort {
 		s.config.ListenPortMin = 6891

--- a/bittorrent/service.go
+++ b/bittorrent/service.go
@@ -225,6 +225,12 @@ func (s *Service) configure() {
 	settings.SetBool("use_dht_as_fallback", false)
 	settings.SetBool("use_parole_mode", true)
 
+	// Enable TCP and uTP in case if they were disabled and then enabled again without restarting Kodi
+	settings.SetBool("enable_outgoing_tcp", true)
+	settings.SetBool("enable_incoming_tcp", true)
+	settings.SetBool("enable_outgoing_utp", true)
+	settings.SetBool("enable_incoming_utp", true)
+
 	// Disabling services, as they are enabled by default in libtorrent
 	settings.SetBool("enable_upnp", false)
 	settings.SetBool("enable_natpmp", false)
@@ -450,17 +456,6 @@ func (s *Service) configure() {
 		settings.SetInt("min_reconnect_time", 20)
 	}
 
-	if s.config.DisableTCP {
-		log.Info("Disabling TCP...")
-		settings.SetBool("enable_outgoing_tcp", false)
-		settings.SetBool("enable_incoming_tcp", false)
-	}
-	if s.config.DisableUTP {
-		log.Info("Disabling UTP...")
-		settings.SetBool("enable_outgoing_utp", false)
-		settings.SetBool("enable_incoming_utp", false)
-	}
-
 	var listenPorts []string
 	if s.config.ListenAutoDetectPort {
 		s.config.ListenPortMin = 6891
@@ -528,6 +523,17 @@ func (s *Service) configure() {
 }
 
 func (s *Service) startServices() {
+	if s.config.DisableTCP {
+		log.Info("Disabling TCP...")
+		s.PackSettings.SetBool("enable_outgoing_tcp", false)
+		s.PackSettings.SetBool("enable_incoming_tcp", false)
+	}
+	if s.config.DisableUTP {
+		log.Info("Disabling UTP...")
+		s.PackSettings.SetBool("enable_outgoing_utp", false)
+		s.PackSettings.SetBool("enable_incoming_utp", false)
+	}
+
 	if !s.config.DisableLSD {
 		log.Info("Starting LSD...")
 		s.PackSettings.SetBool("enable_lsd", true)


### PR DESCRIPTION
those options were added for anacrolix/torrent
https://github.com/elgatito/elementum/commit/11147be7b3ed07a42e06f16bdbbd4948831024fe

and after migration to libtorrent they were not used.

but libtorrent also supports these options - https://libtorrent.org/reference-Settings.html
so i added their usage.