### PR TITLE
proxy_force can break download b/c of bug in libtorrent so make it configurable

### DIFF
--- a/bittorrent/service.go
+++ b/bittorrent/service.go
@@ -384,8 +384,8 @@ func (s *Service) configure() {
 		// Proxy Tracker connections
 		settings.SetBool("proxy_tracker_connections", config.Get().ProxyUseTracker)
 
-		// ensure no leakage
-		settings.SetBool("force_proxy", true)
+		// ensure no leakage, this may break download
+		settings.SetBool("force_proxy", config.Get().ProxyForce)
 	}
 
 	// Set alert_mask here so it also applies on reconfigure...

--- a/config/config.go
+++ b/config/config.go
@@ -261,6 +261,7 @@ type Configuration struct {
 	ProxyUseHTTP     bool
 	ProxyUseTracker  bool
 	ProxyUseDownload bool
+	ProxyForce       bool
 
 	CompletedMove       bool
 	CompletedMoviesPath string
@@ -751,6 +752,7 @@ func Reload() (ret *Configuration, err error) {
 		ProxyUseHTTP:     settings.ToBool("use_proxy_http"),
 		ProxyUseTracker:  settings.ToBool("use_proxy_tracker"),
 		ProxyUseDownload: settings.ToBool("use_proxy_download"),
+		ProxyForce:       settings.ToBool("proxy_force"),
 
 		CompletedMove:       settings.ToBool("completed_move"),
 		CompletedMoviesPath: settings.ToString("completed_movies_path"),


### PR DESCRIPTION
there is a some bug that prevents download of data and metadata (magnets cannot be not resolved) if proxy_force=true, checked with socks5 and http with local proxy from tinyproxy and proxy from windscribe app. download always "hangs" with proxy_force.
looks like there is some bug in libtorrent 1.1 (that we use) regarding proxy_force option. 

## Related Issue
originally added here https://github.com/elgatito/elementum/pull/84

this PR depends on https://github.com/elgatito/plugin.video.elementum/pull/1096

[test build](https://disk.yandex.by/d/oO5Vs2Diarzzhg).