### PR TITLE
Read resp.Bosy in TestRepositoryURL to avoid error from repo side.

### DIFF
--- a/util/ip/ip.go
+++ b/util/ip/ip.go
@@ -3,6 +3,7 @@ package ip
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -269,6 +270,7 @@ func TestRepositoryURL() error {
 		return err
 	}
 	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
 
 	return nil
 }


### PR DESCRIPTION
fixes https://github.com/elgatito/plugin.video.elementum/issues/1090

if we do not read body then python server from repository.elementumorg is unhappy and prints error `ERROR: error: [Errno 104] Connection reset by peer` in log and this confuses users.