### PR TITLE
Trakt token now expires every 24h

### DIFF
--- a/util/reqapi/request.go
+++ b/util/reqapi/request.go
@@ -239,6 +239,9 @@ func (r *Request) Do() (err error) {
 			} else if r.ResponseStatusCode < 200 || r.ResponseStatusCode >= 300 {
 				log.Errorf("Bad status getting %s with %+v on %s: %d/%s", r.Description, r.Params, r.URL, r.ResponseStatusCode, r.ResponseStatus)
 				err = errors.New(r.ResponseStatus)
+				if resp != nil && resp.ResponseBody != nil {
+					log.Debugf("Response body: %s", resp.ResponseBody.String())
+				}
 				r.Error(err)
 				return err
 			}


### PR DESCRIPTION
Big news - https://github.com/trakt/api-help/discussions/495

>Starting on March 4, 2025, an OAuth access_token will expire in 24 hours, instead of 3 months.

But we do not refresh token on start and we refresh token only after 12h after start, every 12h.
So in our case token will expire every day with this new change from trakt.
And since we do not automatically refresh token on start - every day user would need to re-authorize elementum in trakt.

So I made new function called `RefreshToken()` which now runs on start (so if token already expired - we refresh it) and then every 1 hour and does refresh if it is less than 90 minutes before expiration.
I also added back usage of LOCALIZE[30576] (it was deleted after migration to reqapi [here](https://github.com/elgatito/elementum/commit/fbd38995a7978c49532fe0d24fe320feb97df28b#diff-9bd58957da61970906cb80a2080df8bbd021d73af5d52b68632f9efd810314e5L656), so now it clear to user if refresh_token is dead - but it would be nice to add it to all requests somehow) and I set `config.Get().TraktToken*` values after refresh so function will not try to refresh token again.

fixes https://github.com/elgatito/plugin.video.elementum/issues/1101