### PR TITLE
Fix double decode of file url, attempt 2.

### DIFF
--- a/bittorrent/torrent_file.go
+++ b/bittorrent/torrent_file.go
@@ -503,7 +503,7 @@ func (t *TorrentFile) Download() ([]byte, error) {
 		for _, part := range parts[1:] {
 			if keyVal := strings.SplitN(part, "=", 2); len(keyVal) > 1 {
 				req.Header.Add(keyVal[0], keyVal[1])
-				log.Debugf("Added header %q: %q", keyVal[0], keyVal[1])
+				//log.Debugf("Added header %q: %q", keyVal[0], keyVal[1])
 			}
 		}
 	}

--- a/bittorrent/torrentfs.go
+++ b/bittorrent/torrentfs.go
@@ -68,9 +68,9 @@ func NewTorrentFS(service *Service, method string) *TorrentFS {
 
 // Open ...
 func (tfs *TorrentFS) Open(uname string) (http.File, error) {
-	// URLs always come with "/" as the separator, but while we compare it to file storage path,
-	// it should be using OS specific separators in the path
-	name := util.DecodeFileURL(uname)
+	// URL always comes with "/" as the separator, but while we compare it to file storage path,
+	// we should use OS specific separator in the path. URL comes already decoded.
+	name := util.ReconstructFileURL(uname)
 
 	var file http.File
 	var err error

--- a/util/url.go
+++ b/util/url.go
@@ -22,7 +22,7 @@ func TrailerURL(u string) (ret string) {
 	return
 }
 
-// DecodeFileURL decodes file path from url
+// DecodeFileURL decodes file path from raw (not yet decoded) url
 func DecodeFileURL(u string) (ret string) {
 	us := strings.Split(u, string("/"))
 	for i, v := range us {
@@ -40,4 +40,9 @@ func EncodeFileURL(u string) (ret string) {
 	}
 
 	return strings.Join(us, "/")
+}
+
+// ReconstructFileURL reconstructs file path from already decoded url with correct separator
+func ReconstructFileURL(u string) (ret string) {
+	return strings.Join(strings.Split(u, string("/")), string(os.PathSeparator))
 }


### PR DESCRIPTION
Continuation of https://github.com/elgatito/elementum/pull/144

But with fix https://github.com/elgatito/plugin.video.elementum/issues/1104

the issue it that DecodeFileURL does 2 things:
1. decode URL - this was unnecessary and created bug with double decode, but I tested only on Linux+Android, where separator is `/`, same as in URL.
2. change separator to OS specific - this is necessary and deleting DecodeFileURL introduced new bug in Windows, where separator is `\`: https://github.com/elgatito/plugin.video.elementum/issues/1104

TESTS:

Linux:

before:
```
INFO bittorrent ▶ Open original uname is /Нападение одиночки на иной мир %7C Hitoribocchi no Isekai Kouryaku/[AniMaunt] Hitoribocchi no Isekai Kouryaku - 01.mp4
INFO bittorrent ▶ Open after DecodeFileURL name is /Нападение одиночки на иной мир | Hitoribocchi no Isekai Kouryaku/[AniMaunt] Hitoribocchi no Isekai Kouryaku - 01.mp4
```
**note this incorrect `|`.**

after:
```
INFO bittorrent ▶ Open original uname is /Нападение одиночки на иной мир %7C Hitoribocchi no Isekai Kouryaku/[AniMaunt] Hitoribocchi no Isekai Kouryaku - 01.mp4
INFO bittorrent ▶ Open after ReconstructFileURL name is /Нападение одиночки на иной мир %7C Hitoribocchi no Isekai Kouryaku/[AniMaunt] Hitoribocchi no Isekai Kouryaku - 01.mp4
```

Windows:

before:
```
INFO  bittorrent   ▶ Open             Opening \Нападение одиночки на иной мир | Hitoribocchi no Isekai Kouryaku\[AniMaunt] Hitoribocchi no Isekai Kouryaku - 01.mp4
```
**note this incorrect `|`.**

after:
```
INFO  bittorrent   ▶ Open             original uname is /Нападение одиночки на иной мир %7C Hitoribocchi no Isekai Kouryaku/[AniMaunt] Hitoribocchi no Isekai Kouryaku - 01.mp4
INFO  bittorrent   ▶ Open             after ReconstructFileURL name is \Нападение одиночки на иной мир %7C Hitoribocchi no Isekai Kouryaku\[AniMaunt] Hitoribocchi no Isekai Kouryaku - 01.mp4
INFO  bittorrent   ▶ Open             Opening \Нападение одиночки на иной мир %7C Hitoribocchi no Isekai Kouryaku\[AniMaunt] Hitoribocchi no Isekai Kouryaku - 01.mp4
```

torrent that failed in https://github.com/elgatito/plugin.video.elementum/issues/1104 now works too:
```
INFO  bittorrent   ▶ Open             original uname is /The.White.Lotus.S03.1080p.AMZN.WEB-DL.H.264-EniaHD/The.White.Lotus.S03E01.Same.Spirits.New.Forms.1080p.AMZN.WEB-DL.H.264-EniaHD.mkv
INFO  bittorrent   ▶ Open             after ReconstructFileURL name is \The.White.Lotus.S03.1080p.AMZN.WEB-DL.H.264-EniaHD\The.White.Lotus.S03E01.Same.Spirits.New.Forms.1080p.AMZN.WEB-DL.H.264-EniaHD.mkv
INFO  bittorrent   ▶ Open             Opening \The.White.Lotus.S03.1080p.AMZN.WEB-DL.H.264-EniaHD\The.White.Lotus.S03E01.Same.Spirits.New.Forms.1080p.AMZN.WEB-DL.H.264-EniaHD.mkv
```