### PR TITLE
Add "re-check torrent's data" menu.

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -143,6 +143,7 @@ func Routes(s *bittorrent.Service, shutdown func(code int)) *gin.Engine {
 		torrents.GET("/move/:torrentId", MoveTorrent(s))
 		torrents.GET("/pause/:torrentId", PauseTorrent(s))
 		torrents.GET("/resume/:torrentId", ResumeTorrent(s))
+		torrents.GET("/recheck/:torrentId", RecheckTorrent(s))
 		torrents.GET("/delete/:torrentId", RemoveTorrent(s))
 		torrents.GET("/downloadall/:torrentId", DownloadAllTorrent(s))
 		torrents.GET("/undownloadall/:torrentId", UnDownloadAllTorrent(s))

--- a/api/torrents.go
+++ b/api/torrents.go
@@ -316,6 +316,8 @@ func ListTorrents(s *bittorrent.Service) gin.HandlerFunc {
 				} else {
 					item.ContextMenu = append(item.ContextMenu, []string{"LOCALIZE[30532]", fmt.Sprintf("RunPlugin(%s)", URLForXBMC("/torrents/undownloadall/%s", t.InfoHash()))})
 				}
+
+				item.ContextMenu = append(item.ContextMenu, []string{"LOCALIZE[30714]", fmt.Sprintf("RunPlugin(%s)", URLForXBMC("/torrents/recheck/%s", t.InfoHash()))})
 			}
 
 			item.IsPlayable = true
@@ -576,6 +578,27 @@ func PauseTorrent(s *bittorrent.Service) gin.HandlerFunc {
 		}
 
 		torrent.Pause()
+
+		xbmcHost.Refresh()
+		ctx.String(200, "")
+	}
+}
+
+// RecheckTorrent re-checks torrent's data
+func RecheckTorrent(s *bittorrent.Service) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		defer perf.ScopeTimer()()
+
+		xbmcHost, _ := xbmc.GetXBMCHostWithContext(ctx)
+
+		torrentID := ctx.Params.ByName("torrentId")
+		torrent, err := GetTorrentFromParam(s, torrentID)
+		if err != nil {
+			ctx.Error(fmt.Errorf("Unable to re-check torrent with index %s", torrentID))
+			return
+		}
+
+		torrent.ForceRecheck()
 
 		xbmcHost.Refresh()
 		ctx.String(200, "")

--- a/bittorrent/torrent.go
+++ b/bittorrent/torrent.go
@@ -1273,6 +1273,17 @@ func (t *Torrent) Resume() {
 	t.IsPaused = false
 }
 
+// ForceRecheck re-checks torrent's data
+func (t *Torrent) ForceRecheck() {
+	if t.Closer.IsSet() || t.th == nil || t.th.Swigcptr() == 0 {
+		return
+	}
+
+	log.Infof("Re-checking torrent: %s", t.InfoHash())
+
+	t.th.ForceRecheck()
+}
+
 // GetDBItem ...
 func (t *Torrent) GetDBItem() *database.BTItem {
 	return t.DBItem

--- a/trakt/movies.go
+++ b/trakt/movies.go
@@ -618,7 +618,6 @@ func (movie *Movie) ToListItem() (item *xbmc.ListItem) {
 	if lm, err := uid.GetMovieByTMDB(movie.IDs.TMDB); lm != nil && err == nil {
 		item.Info.DBID = lm.UIDs.Kodi
 		if lm.Resume != nil {
-			log.Debugf("%s lm.Resume.Position: %f", movie.Title, lm.Resume.Position)
 			item.Properties.ResumeTime = strconv.FormatFloat(lm.Resume.Position, 'f', 6, 64)
 			item.Properties.TotalTime = strconv.FormatFloat(lm.Resume.Total, 'f', 6, 64)
 		}

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -945,7 +945,6 @@ func (episode *Episode) ToListItem(show *Show, tmdbShow *tmdb.Show) (item *xbmc.
 		if le := ls.GetEpisode(episode.Season, episode.Number); le != nil {
 			item.Info.DBID = le.UIDs.Kodi
 			if le.Resume != nil {
-				log.Debugf("%s S%02dE%02d le.Resume.Position: %f", show.Title, episode.Season, episode.Number, le.Resume.Position)
 				item.Properties.ResumeTime = strconv.FormatFloat(le.Resume.Position, 'f', 6, 64)
 				item.Properties.TotalTime = strconv.FormatFloat(le.Resume.Total, 'f', 6, 64)
 			}


### PR DESCRIPTION
Re-check be convenient after migration to new device, for example.
It also needs https://github.com/elgatito/elementum/pull/156

**Btw, i think that delete and move actions only make sense for file storage.** Maybe we should move them to inside of `if !t.IsMemoryStorage() {` ?

Also i removed leftovers of logging that was partially removed in 24cf6876f393b8b025f9d04caa417bb8da895bb3

