### PR TITLE
Changes for client-server mode: add -tempPath, fix -logPath, fix AddonIcon()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -325,6 +325,7 @@ var (
 		ConfigPath     string `help:"Custom path to Elementum config (Yaml or JSON format)"`
 		AddonPath      string `help:"Custom path to addon folder (where Kodi stored files, coming with addon zip)"`
 		ProfilePath    string `help:"Custom path to addon files folder (where Elementum will write data)"`
+		TempPath       string `help:"Custom path to temp folder (where Elementum will write temporary files)"`
 		LibraryPath    string `help:"Custom path to addon library folder"`
 		TorrentsPath   string `help:"Custom path to addon torrent files folder"`
 		DownloadsPath  string `help:"Custom path to addon downloads folder"`
@@ -409,6 +410,10 @@ func Reload() (ret *Configuration, err error) {
 	if Args.ProfilePath != "" {
 		log.Infof("Setting custom profile path to: %s", Args.ProfilePath)
 		configBundle.Info.Profile = Args.ProfilePath
+	}
+	if Args.TempPath != "" {
+		log.Infof("Setting custom temp path to: %s", Args.TempPath)
+		configBundle.Info.TempPath = Args.TempPath
 	}
 
 	if Args.ExportConfig != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -910,7 +910,7 @@ func Reload() (ret *Configuration, err error) {
 
 // AddonIcon ...
 func AddonIcon() string {
-	return filepath.Join(Get().Info.Path, "icon.png")
+	return Get().Info.Icon
 }
 
 // AddonResource ...

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func setupLogging() {
 	if config.Args.LogPath != "" {
 		logPath = config.Args.LogPath
 	}
-	if logPath != "" && util.IsWritablePath(filepath.Base(logPath)) == nil {
+	if logPath != "" && util.IsWritablePath(filepath.Dir(logPath)) == nil {
 		fileLogger = &lumberjack.Logger{
 			Filename:   logPath,
 			MaxSize:    10, // Size in Megabytes


### PR DESCRIPTION
* Add `-tempPath` command line option. Needed for client-server mode.
* Fix `-logPath` command line option.
* Fix `AddonIcon()`. We should return icon path supplied by Kodi instead of "profile path" + "icon.png", in server mode path to profile can be different. (in regular mode - no difference)