### PR TITLE
API logs also should go to logPath if it is defined.

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"path/filepath"
+	"reflect"
 	"time"
 
 	"github.com/elgatito/elementum/api/repository"
@@ -73,12 +75,18 @@ func Auth() gin.HandlerFunc {
 }
 
 // Routes ...
-func Routes(s *bittorrent.Service, shutdown func(code int)) *gin.Engine {
+func Routes(s *bittorrent.Service, shutdown func(code int), fileLogger io.Writer) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
+
+	logOutput := gin.DefaultWriter
+	if fileLogger != nil && !reflect.ValueOf(fileLogger).IsNil() {
+		logOutput = fileLogger
+	}
+
 	r.Use(gin.LoggerWithConfig(gin.LoggerConfig{
 		Formatter: logFormatter,
-		Output:    gin.DefaultWriter,
+		Output:    logOutput,
 		SkipPaths: []string{"/torrents/list", "/notification"},
 	}))
 	r.Use(CORS())

--- a/main.go
+++ b/main.go
@@ -265,7 +265,7 @@ func main() {
 	})
 	http.Handle("/debug/vars", expvar.Handler())
 
-	http.Handle("/", api.Routes(s, shutdown))
+	http.Handle("/", api.Routes(s, shutdown, fileLogger))
 
 	http.Handle("/files/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Connection", "close")


### PR DESCRIPTION
i mean logs like
`[GIN] 2025/03/10 - 17:43:06 | 200 |  202.082453ms |   391 kB |       127.0.0.1 | GET      "/movies/trakt/watchlist?doresume=false"`

currently they always go to stdout.

возможно код можно как-то изменить чтобы проверка на пустой интерфейс была красивее.