### PR TITLE
Add -serverExternalIp command line parameter.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -315,12 +315,14 @@ var (
 		RemoteHost string `help:"Remote host IP or Hostname (Host with plugin.video.elementum running)"`
 		RemotePort int    `help:"Remote host Port (Host with plugin.video.elementum running)"`
 
+		ServerExternalIP string `help:"Set to external IP if you run server behind NAT (e.g. in container with NAT network), so elementum will use this IP in replies and will not try to identify Kodi's IP based on client's IP"`
+
 		LocalHost     string `help:"Local host IP (IP that would be used for running Elementum HTTP server on a local host)"`
 		LocalPort     int    `help:"Local host Port (Port that would be used for running Elementum HTTP server on a local host)"`
 		LocalLogin    string `help:"Local host Login (To use for authentication from plugin.video.elementum calls)"`
 		LocalPassword string `help:"Local host Password (To use for authentication from plugin.video.elementum calls)"`
 
-		LogPath string `help:"Log location path"`
+		LogPath string `help:"Log file location path"`
 
 		ConfigPath     string `help:"Custom path to Elementum config (Yaml or JSON format)"`
 		AddonPath      string `help:"Custom path to addon folder (where Kodi stored files, coming with addon zip)"`

--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func main() {
 	log.Infof("Version: %s LibTorrent: %s Go: %s, Threads: %d", ident.GetVersion(), ident.GetTorrentVersion(), runtime.Version(), runtime.GOMAXPROCS(0))
 
 	// Init default XBMC connections
-	xbmc.Init()
+	xbmc.Init(config.Args.ServerExternalIP)
 
 	conf, err := config.Reload()
 	if err != nil || conf == nil {

--- a/util/ip/ip.go
+++ b/util/ip/ip.go
@@ -136,7 +136,10 @@ func GetHTTPHost(xbmcHost *xbmc.XBMCHost) string {
 	if xbmcHost != nil && xbmcHost.Host != "" {
 		host = xbmcHost.Host
 	} else if config.Args.RemoteHost == "" || config.Args.RemoteHost == "127.0.0.1" {
-		if localIP, err := LocalIP(xbmcHost); err == nil {
+		// If behind NAT - use external server IP to create URL for client.
+		if config.Args.ServerExternalIP != "" {
+			host = config.Args.ServerExternalIP
+		} else if localIP, err := LocalIP(xbmcHost); err == nil {
 			host = localIP.String()
 		} else {
 			log.Debugf("Error getting local IP: %s", err)
@@ -157,7 +160,10 @@ func GetContextHTTPHost(ctx *gin.Context) string {
 	// to avoid situations when ip has changed and Kodi expects it anyway.
 	host := "127.0.0.1"
 	if (config.Args.RemoteHost != "" && config.Args.RemoteHost != "127.0.0.1") || !strings.HasPrefix(ctx.Request.RemoteAddr, "127.0.0.1") {
-		if localIP, err := LocalIP(nil); err == nil {
+		// If behind NAT - use external server IP to create URL for client.
+		if config.Args.ServerExternalIP != "" {
+			host = config.Args.ServerExternalIP
+		} else if localIP, err := LocalIP(nil); err == nil {
 			host = localIP.String()
 		} else {
 			log.Debugf("Error getting local IP: %s", err)

--- a/xbmc/jsonrpc.go
+++ b/xbmc/jsonrpc.go
@@ -31,12 +31,16 @@ var (
 	// XBMCExJSONRPCPort is a port for XBMCExJSONRPC (RCP of python part of the plugin)
 	XBMCExJSONRPCPort = "65221"
 
+	BehindNAT = false
+
 	mu sync.RWMutex
 )
 
-func Init() {
+func Init(externalIP string) {
 	mu.Lock()
 	defer mu.Unlock()
+
+	BehindNAT = externalIP != ""
 
 	XBMCHosts = []*XBMCHost{}
 	for _, host := range []string{
@@ -123,7 +127,8 @@ func GetLocalXBMCHost() (*XBMCHost, error) {
 func GetXBMCHostWithContext(ctx *gin.Context) (*XBMCHost, error) {
 	// If request is not coming from addon's python part - then it can be a browser request or Kodi,
 	// so we communicate with any existing Kodi connection.
-	if ctx.GetHeader("User-Agent") != "plugin.video.elementum" {
+	// Same if we are behind NAT - in this case ClientIP is NAT gateway IP, so we should not use it.
+	if ctx.GetHeader("User-Agent") != "plugin.video.elementum" || BehindNAT {
 		return GetLocalXBMCHost()
 	}
 


### PR DESCRIPTION
Set it to external IP if you run server behind NAT (e.g. in container with NAT network), so elementum will use this IP in replies and will not try to identify Kodi's IP based on client's IP.

Looks like in Windows Docker Desktop "bridge" and "host" network drivers (in WSL and Hyper-V mode) work as NAT behind the scene, so elementum can't identify Kodi's IP based on request IP since elementum sees IP of NAT gateway but not real client IP (unlike with Linux Docker Engine). Also elementum will use internal IP in replies to client and client will not be able to connect to that internal IP.
Thus, we must use this special `-serverExternalIp=` parameter so elementum will use this IP in replies and will not try to identify Kodi's IP based on client's IP (`-remoteHost=` value always will be used as Kodi's IP).