### PR TITLE
RomanizeHepburn: use simplest way.

### DIFF
--- a/providers/util.go
+++ b/providers/util.go
@@ -26,8 +26,8 @@ func RemoveTrailingApostrophes(str string) string {
 // RomanizeHepburn ...
 // as per http://en.wikipedia.org/wiki/Hepburn_romanization#Variations
 func RomanizeHepburn(str string) string {
-	str = strings.Replace(str, "ō", "ou", -1)
-	str = strings.Replace(str, "ū", "uu", -1)
+	str = strings.Replace(str, "ō", "o", -1)
+	str = strings.Replace(str, "ū", "u", -1)
 	return str
 }
 


### PR DESCRIPTION
Not indicated, no additional letter added.
So Shōgun -> Shogun instead of Shougun. fixes https://github.com/elgatito/plugin.video.elementum/issues/1105

там прямо в коде есть коммент https://en.wikipedia.org/wiki/Hepburn_romanization#Variations
а там написано
>Tokyo – not indicated at all. Common for Japanese words that have been adopted into English, and the de facto convention for Hepburn used in signs and other English-language information around Japan.

т.е. казалось бы стоит просто убирать эти макроны https://ru.wikipedia.org/wiki/%D0%9C%D0%B0%D0%BA%D1%80%D0%BE%D0%BD_(%D0%B4%D0%B8%D0%B0%D0%BA%D1%80%D0%B8%D1%82%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%B8%D0%B9_%D0%B7%D0%BD%D0%B0%D0%BA) и всё, это вроде как самый популярный метод.

не знаю почему был сделан выбор в строну 
>Toukyou – written using [kana](https://en.wikipedia.org/wiki/Kana) spelling: ō as ou or oo (depending on the kana).

где ō может быть как ou так и oo, что ещё больше запутывает.

ну и как я вижу торренты или создают как есть, аля Shōgun (и большинство трекеров нормально ищут такое кстати), или без макрона, аля Shogun.

Думаю самое безопасное это убрать макроны и использовать вариант без дополнительных букв.

Но тут открыто к обсуждению, если что.