### PR TITLE
Set config.ListenAutoDetectIP=false is user used -listenInterfaces option.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -809,6 +809,7 @@ func Reload() (ret *Configuration, err error) {
 	// Use custom interfaces
 	if len(Args.ListenInterfaces) > 0 {
 		newConfig.ListenInterfaces = strings.Join(Args.ListenInterfaces, ",")
+		newConfig.ListenAutoDetectIP = false
 	}
 	if len(Args.OutgoingInterfaces) > 0 {
 		newConfig.OutgoingInterfaces = strings.Join(Args.OutgoingInterfaces, ",")


### PR DESCRIPTION
otherwise it will not be used with default config
https://github.com/elgatito/elementum/blob/54e7f16835978e947edf601713edb6a00b6e1ded/bittorrent/service.go#L2227
since listen_autodetect_ip=true
https://github.com/elgatito/plugin.video.elementum/blob/c67fc246277f997e79b1d725fa88d0cce6282aee/resources/settings.xml#L188

e.g. when user connects to Kodi for elementum's settings and does not use custom config from  `-exportConfig/-configPath` - and this is default way, imho.