### PR TITLE
Revoke access_token in Deauthorize().

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -336,7 +336,7 @@ func Routes(s *bittorrent.Service, shutdown func(code int), fileLogger io.Writer
 		show.GET("/:showId/collection/add", AddShowToCollection)
 		show.GET("/:showId/collection/remove", RemoveShowFromCollection)
 	}
-	// TODO
+	// TODO: add routes for episode.
 	// episode := r.Group("/episode")
 	// {
 	// 	episode.GET("/:episodeId/watchlist/add", AddEpisodeToWatchlist)


### PR DESCRIPTION
https://trakt.docs.apiary.io/#reference/authentication-oauth/revoke-token

>An access_token can be revoked when a user signs out of their Trakt account in your app. This is not required, but might improve the user experience so the user doesn't have an unused app connection hanging around.

шаг опциональный, но не повредит, если ошибка - то игнорируем, ответ там тоже пустой - тоже игнорируем.