### PR TITLE
RemotePort option must override XBMCExJSONRPCPort

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -384,6 +384,9 @@ func Reload() (ret *Configuration, err error) {
 
 	// Reloading RPC Hosts
 	var xbmcHost *xbmc.XBMCHost
+	if strconv.Itoa(Args.RemotePort) != xbmc.XBMCExJSONRPCPort {
+		xbmc.XBMCExJSONRPCPort = strconv.Itoa(Args.RemotePort)
+	}
 	if Args.RemoteHost != "" {
 		log.Infof("Setting remote address to %s:%d", Args.RemoteHost, Args.RemotePort)
 		xbmcHost, err = xbmc.AddLocalXBMCHost(Args.RemoteHost)

--- a/xbmc/jsonrpc.go
+++ b/xbmc/jsonrpc.go
@@ -25,10 +25,10 @@ var (
 	XBMCLocalHost *XBMCHost = nil
 	XBMCHosts               = []*XBMCHost{}
 
-	// XBMCJSONRPCPort is a port for XBMCJSONRPC (RCP of Kodi)
+	// XBMCJSONRPCPort is a port for XBMCJSONRPC (RPC of Kodi)
 	XBMCJSONRPCPort = "9090"
 
-	// XBMCExJSONRPCPort is a port for XBMCExJSONRPC (RCP of python part of the plugin)
+	// XBMCExJSONRPCPort is a port for XBMCExJSONRPC (RPC of Python part of the addon)
 	XBMCExJSONRPCPort = "65221"
 
 	BehindNAT = false


### PR DESCRIPTION
after https://github.com/elgatito/elementum/commit/1dba83b97282cf1cfb3eaafd4792e14947cf2e5c#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3ef
`RemotePort` was not really used and we always used hardcoded port from `XBMCExJSONRPCPort` variable (65221).
No user again can specify custom port for RPC of Python part of the addon.

for https://github.com/elgatito/plugin.video.elementum/issues/1117